### PR TITLE
feat: support job corrections in worker framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,54 @@ async def handle_payment(job: ConnectedJobContext) -> dict[str, object]:
 
 The `error_code` must match the error code defined on a BPMN error catch event in your process model. If no catch event matches, the job becomes an incident.
 
+### Job Corrections (User Task Listeners)
+
+When a job worker handles a [user task listener](https://docs.camunda.io/docs/components/concepts/user-task-listeners/), it can correct task properties (assignee, due date, candidate groups, etc.) as part of the completion. Return a `JobCompletionRequest` with a `result` containing `JobResultCorrections`:
+
+```python
+from camunda_orchestration_sdk import ConnectedJobContext
+from camunda_orchestration_sdk.models import (
+    JobCompletionRequest,
+    JobResultUserTask,
+    JobResultCorrections,
+)
+
+async def validate_task(job: ConnectedJobContext) -> JobCompletionRequest:
+    return JobCompletionRequest(
+        result=JobResultUserTask(
+            type_="userTask",
+            corrections=JobResultCorrections(
+                assignee="corrected-user",
+                priority=80,
+            ),
+        ),
+    )
+```
+
+To deny a task completion (reject the work), set `denied=True`:
+
+```python
+async def review_task(job: ConnectedJobContext) -> JobCompletionRequest:
+    return JobCompletionRequest(
+        result=JobResultUserTask(
+            type_="userTask",
+            denied=True,
+            denied_reason="Insufficient documentation",
+        ),
+    )
+```
+
+| Correctable attribute | Type | Clear value |
+|---|---|---|
+| `assignee` | `str` | Empty string `""` |
+| `due_date` | `datetime` | Empty string `""` |
+| `follow_up_date` | `datetime` | Empty string `""` |
+| `candidate_users` | `list[str]` | Empty list `[]` |
+| `candidate_groups` | `list[str]` | Empty list `[]` |
+| `priority` | `int` (0–100) | — |
+
+Omitting an attribute or passing `None` preserves the persisted value. This works with all handler types (async, thread, and process).
+
 ## Error Handling
 
 The SDK raises typed exceptions for API errors. Each HTTP error status code has a corresponding exception class (e.g. `BadRequestError` for 400, `NotFoundError` for 404). Every exception carries the `operation_id` of the method that raised it:

--- a/generated/camunda_orchestration_sdk/runtime/job_worker.py
+++ b/generated/camunda_orchestration_sdk/runtime/job_worker.py
@@ -154,7 +154,9 @@ ConnectedAsyncJobHandler = Callable[
     Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None],
 ]
 # Handlers that accept SyncJobContext (thread strategy).
-ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | None]
+ConnectedSyncJobHandler = Callable[
+    [SyncJobContext], dict[str, Any] | JobCompletionRequest | None
+]
 ConnectedJobHandler = ConnectedAsyncJobHandler | ConnectedSyncJobHandler
 
 # Handlers that accept only JobContext (process strategy).
@@ -162,7 +164,9 @@ ConnectedJobHandler = ConnectedAsyncJobHandler | ConnectedSyncJobHandler
 IsolatedAsyncJobHandler = Callable[
     [JobContext], Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None]
 ]
-IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | None]
+IsolatedSyncJobHandler = Callable[
+    [JobContext], dict[str, Any] | JobCompletionRequest | None
+]
 IsolatedJobHandler = IsolatedAsyncJobHandler | IsolatedSyncJobHandler
 
 # Internal union — used by JobWorker internals.

--- a/runtime/job_worker.py
+++ b/runtime/job_worker.py
@@ -154,7 +154,7 @@ ConnectedAsyncJobHandler = Callable[
     Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None],
 ]
 # Handlers that accept SyncJobContext (thread strategy).
-ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | None]
+ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | JobCompletionRequest | None]
 ConnectedJobHandler = ConnectedAsyncJobHandler | ConnectedSyncJobHandler
 
 # Handlers that accept only JobContext (process strategy).
@@ -162,7 +162,7 @@ ConnectedJobHandler = ConnectedAsyncJobHandler | ConnectedSyncJobHandler
 IsolatedAsyncJobHandler = Callable[
     [JobContext], Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None]
 ]
-IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | None]
+IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | JobCompletionRequest | None]
 IsolatedJobHandler = IsolatedAsyncJobHandler | IsolatedSyncJobHandler
 
 # Internal union — used by JobWorker internals.

--- a/stubs/camunda_orchestration_sdk/runtime/job_worker.pyi
+++ b/stubs/camunda_orchestration_sdk/runtime/job_worker.pyi
@@ -36,12 +36,12 @@ ConnectedAsyncJobHandler = Callable[
     [ConnectedJobContext],
     Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None],
 ]
-ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | None]
+ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | JobCompletionRequest | None]
 ConnectedJobHandler = ConnectedAsyncJobHandler | ConnectedSyncJobHandler
 IsolatedAsyncJobHandler = Callable[
     [JobContext], Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None]
 ]
-IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | None]
+IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | JobCompletionRequest | None]
 IsolatedJobHandler = IsolatedAsyncJobHandler | IsolatedSyncJobHandler
 JobHandler = ConnectedJobHandler | IsolatedJobHandler
 AsyncJobHandler = IsolatedAsyncJobHandler

--- a/tests/acceptance/test_job_worker.py
+++ b/tests/acceptance/test_job_worker.py
@@ -13,6 +13,8 @@ from camunda_orchestration_sdk.models.activated_job_result import (
     ActivatedJobResult,
 )
 from camunda_orchestration_sdk.models.job_completion_request import JobCompletionRequest
+from camunda_orchestration_sdk.models.job_result_user_task import JobResultUserTask
+from camunda_orchestration_sdk.models.job_result_corrections import JobResultCorrections
 from camunda_orchestration_sdk.models.job_activation_result import (
     JobActivationResult,
 )
@@ -71,6 +73,38 @@ async def test_job_completion(mock_client: MagicMock, mock_job_item: JobContext)
     call_args = mock_client.complete_job.call_args
     assert call_args.kwargs["job_key"] == 12345
     assert isinstance(call_args.kwargs["data"], JobCompletionRequest)
+
+
+@pytest.mark.asyncio
+async def test_job_completion_with_corrections(mock_client: MagicMock, mock_job_item: JobContext):
+    """Sync-style handler can return a JobCompletionRequest with corrections."""
+
+    def callback(job: JobContext) -> JobCompletionRequest:
+        return JobCompletionRequest(
+            result=JobResultUserTask(
+                type_="userTask",
+                corrections=JobResultCorrections(
+                    assignee="corrected-user",
+                    priority=80,
+                ),
+            ),
+        )
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.complete_job.assert_called_once()
+    call_args = mock_client.complete_job.call_args
+    assert call_args.kwargs["job_key"] == 12345
+    data = call_args.kwargs["data"]
+    assert isinstance(data, JobCompletionRequest)
+    assert isinstance(data.result, JobResultUserTask)
+    assert data.result.type_ == "userTask"
+    assert isinstance(data.result.corrections, JobResultCorrections)
+    assert data.result.corrections.assignee == "corrected-user"
+    assert data.result.corrections.priority == 80
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enables all worker handler types (async, sync/thread, process) to return job corrections when completing user task listener jobs.

Closes #19

## Problem

Sync handler type signatures (`ConnectedSyncJobHandler`, `IsolatedSyncJobHandler`) only allowed `dict[str, Any] | None` as return types. This prevented sync handlers from returning a `JobCompletionRequest` — the only way to include job corrections or task denial results.

The runtime code already handled `JobCompletionRequest` returns correctly (via `isinstance` check), so the restriction was purely at the type level.

## Changes

### Type fix (`runtime/job_worker.py`)
```python
# Before
ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | None]
IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | None]

# After
ConnectedSyncJobHandler = Callable[[SyncJobContext], dict[str, Any] | JobCompletionRequest | None]
IsolatedSyncJobHandler = Callable[[JobContext], dict[str, Any] | JobCompletionRequest | None]
```

### Test (`tests/acceptance/test_job_worker.py`)
- `test_job_completion_with_corrections` — verifies a sync handler can return a `JobCompletionRequest` with `JobResultUserTask` corrections (assignee + priority), and that the data flows through to `complete_job` correctly.

### Documentation (`README.md`)
- New **"Job Corrections (User Task Listeners)"** section with:
  - Example: returning corrections (assignee, priority)
  - Example: denying a task completion
  - Table of all correctable attributes with clear values

## Usage

```python
from camunda_orchestration_sdk import ConnectedJobContext
from camunda_orchestration_sdk.models import (
    JobCompletionRequest, JobResultUserTask, JobResultCorrections,
)

async def validate_task(job: ConnectedJobContext) -> JobCompletionRequest:
    return JobCompletionRequest(
        result=JobResultUserTask(
            type_="userTask",
            corrections=JobResultCorrections(assignee="corrected-user", priority=80),
        ),
    )
```

## Verification

- 104 acceptance tests pass
- 0 pyright errors
- 0 ruff lint errors