### PR TITLE
fix: harden README code injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ generate: clean install bundle-spec
 	uv run pyright
 	uv run pyright examples/
 	uv run pytest -q tests/acceptance
-	uv run python scripts/sync-readme-snippets.py
+	uv run python scripts/sync-readme-snippets.py --check
 	uv run scripts/generate_config_reference.py
 
 # Generate using already-bundled spec (skip fetch, fast local iteration)
@@ -35,7 +35,7 @@ generate-local: clean install
 	uv run pyright
 	uv run pyright examples/
 	uv run pytest -q tests/acceptance
-	uv run python scripts/sync-readme-snippets.py
+	uv run python scripts/sync-readme-snippets.py --check
 	uv run scripts/generate_config_reference.py
 
 clean:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The SDK provides two clients with identical API surfaces:
 
 Both clients share the same method names and parameters — the only difference is calling convention:
 
-<!-- snippet:ReadmeSyncClient -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeSyncClient -->
 ```python
 # Sync
 from camunda_orchestration_sdk import CamundaClient
@@ -86,7 +86,7 @@ with CamundaClient() as client:
     topology = client.get_topology()
 ```
 
-<!-- snippet:ReadmeAsyncClient -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeAsyncClient -->
 ```python
 # Async
 import asyncio
@@ -117,7 +117,7 @@ Semantic types make these identifiers **distinct at the type level**. Pyright (a
 
 Treat semantic types as **opaque identifiers** — receive them from API responses and pass them to subsequent API calls without inspecting or transforming the underlying value:
 
-<!-- snippet:ReadmeSemanticTypes -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeSemanticTypes -->
 ```python
 from camunda_orchestration_sdk import CamundaClient, ProcessCreationByKey
 
@@ -141,6 +141,7 @@ client.cancel_process_instance(process_instance_key=instance_key)
 
 Semantic types are `NewType` wrappers over `str`, so they serialise transparently:
 
+<!-- snippet-exempt: uses hypothetical db.save/db.load pseudo-code -->
 ```python
 from camunda_orchestration_sdk import ProcessDefinitionKey, ProcessInstanceKey
 
@@ -168,7 +169,7 @@ Keep configuration out of application code. Let the client read `CAMUNDA_*` vari
 
 If no configuration is present, the SDK defaults to a local Camunda 8 Run-style endpoint at `http://localhost:8080/v2`.
 
-<!-- snippet:ReadmeZeroConfig -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeZeroConfig -->
 ```python
 from camunda_orchestration_sdk import CamundaAsyncClient, CamundaClient
 
@@ -220,7 +221,7 @@ python your_script.py
 
 You can also enable it via the explicit configuration dict:
 
-<!-- snippet:ReadmeEnvFileLoading -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeEnvFileLoading -->
 ```python
 from camunda_orchestration_sdk import CamundaClient
 
@@ -231,7 +232,7 @@ client = CamundaClient(configuration={"CAMUNDA_LOAD_ENVFILE": "true"})
 
 Only use `configuration={...}` when you must supply or mutate configuration dynamically (e.g. tests, multi-tenant routing, or ephemeral preview environments). Keys mirror their `CAMUNDA_*` environment names.
 
-<!-- snippet:ReadmeProgrammaticConfig -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeProgrammaticConfig -->
 ```python
 from camunda_orchestration_sdk import CamundaClient
 
@@ -285,7 +286,7 @@ CAMUNDA_BASIC_AUTH_PASSWORD=your-password
 
 Or programmatically:
 
-<!-- snippet:ReadmeBasicAuth -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeBasicAuth -->
 ```python
 from camunda_orchestration_sdk import CamundaClient
 
@@ -303,7 +304,7 @@ client = CamundaClient(
 
 Deploy BPMN, DMN, or Form files from disk:
 
-<!-- snippet:ReadmeDeployResources -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeDeployResources -->
 ```python
 from camunda_orchestration_sdk import CamundaClient
 
@@ -319,7 +320,7 @@ with CamundaClient() as client:
 
 The recommended pattern is to obtain keys from a prior API response (e.g. a deployment) and pass them directly — no manual lifting needed:
 
-<!-- snippet:ReadmeCreateProcessInstance -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeCreateProcessInstance -->
 ```python
 from camunda_orchestration_sdk import CamundaClient, ProcessCreationByKey
 
@@ -337,7 +338,7 @@ with CamundaClient() as client:
 
 If you need to restore a key from external storage (database, message queue, config file), wrap the raw string with the semantic type constructor:
 
-<!-- snippet:ReadmeCreateFromStorage -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeCreateFromStorage -->
 ```python
 from camunda_orchestration_sdk import CamundaClient, ProcessCreationByKey, ProcessDefinitionKey
 
@@ -359,7 +360,7 @@ Handlers receive a context object that includes a `client` reference, so your ha
 - **Thread handlers** → `SyncJobContext` with `client: CamundaClient` (call directly)
 - **Process handlers** → plain `JobContext` (no client — cannot be pickled across process boundaries)
 
-<!-- snippet:ReadmeJobWorker -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeJobWorker -->
 ```python
 import asyncio
 
@@ -390,7 +391,7 @@ Because `ConnectedJobContext` and `SyncJobContext` include a `client` reference,
 
 **Async handlers** (`execution_strategy="async"`) — `await` the client method directly:
 
-<!-- snippet:ReadmeAsyncHandler -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeAsyncHandler -->
 ```python
 from camunda_orchestration_sdk import ConnectedJobContext, MessagePublicationRequest, MessagePublicationRequestVariables
 
@@ -413,7 +414,7 @@ async def handle_order(job: ConnectedJobContext) -> dict[str, object]:
 
 **Sync (thread) handlers** (`execution_strategy="thread"`) — `job.client` is a sync `CamundaClient`, so call methods directly:
 
-<!-- snippet:ReadmeSyncHandler -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeSyncHandler -->
 ```python
 from camunda_orchestration_sdk import MessagePublicationRequest, MessagePublicationRequestVariables, SyncJobContext
 
@@ -440,8 +441,9 @@ def handle_order(job: SyncJobContext) -> dict[str, object]:
 
 Each `JobContext` exposes a `log` property — a scoped logger automatically bound with the job's context (job type, worker name, and job key). Use it inside your handler for structured, per-job log output:
 
+<!-- snippet-source: examples/readme.py | regions: ReadmeJobLogger -->
 ```python
-async def handler(job: JobContext) -> dict:
+async def handler(job: ConnectedJobContext) -> dict[str, object]:
     job.log.info(f"Starting work on {job.job_key}")
     # ... do work ...
     job.log.debug("Work completed successfully")
@@ -467,11 +469,12 @@ Job workers support multiple execution strategies to match your workload type. P
 
 **Auto-detection logic:** If your handler is an `async def`, the strategy defaults to `"async"`. If it's a regular `def`, the strategy defaults to `"thread"`. You can override this explicitly:
 
+<!-- snippet-source: examples/readme.py | regions: ReadmeExecutionStrategies -->
 ```python
 from camunda_orchestration_sdk import SyncJobContext, JobContext
 
 # Force thread pool for a sync handler (receives SyncJobContext)
-def io_handler(job: SyncJobContext) -> dict:
+def io_handler(job: SyncJobContext) -> dict[str, object]:
     return {"done": True}
 
 client.create_job_worker(
@@ -481,7 +484,7 @@ client.create_job_worker(
 )
 
 # Force process pool for CPU-heavy work (receives plain JobContext)
-def cpu_handler(job: JobContext) -> dict:
+def cpu_handler(job: JobContext) -> dict[str, object]:
     return {"computed": True}
 
 client.create_job_worker(
@@ -539,7 +542,7 @@ export CAMUNDA_WORKER_TIMEOUT=30000
 export CAMUNDA_WORKER_MAX_CONCURRENT_JOBS=32
 ```
 
-<!-- snippet:ReadmeWorkerDefaultsEnv -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeWorkerDefaultsEnv -->
 ```python
 # No need to set job_timeout_milliseconds on every worker — inherited from env
 client.create_job_worker(
@@ -554,7 +557,7 @@ client.create_job_worker(
 
 Example — set defaults via client constructor:
 
-<!-- snippet:ReadmeWorkerDefaultsClient -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeWorkerDefaultsClient -->
 ```python
 client = CamundaAsyncClient(configuration={
     "CAMUNDA_WORKER_TIMEOUT": "30000",
@@ -577,7 +580,7 @@ client.create_job_worker(
 
 To explicitly fail a job with a custom error message, retry count, and backoff, raise `JobFailure` in your handler:
 
-<!-- snippet:ReadmeFailJob -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeFailJob -->
 ```python
 from camunda_orchestration_sdk import ConnectedJobContext, JobFailure
 
@@ -603,7 +606,7 @@ If an unhandled exception escapes your handler, the job is automatically failed 
 
 To throw a [BPMN error](https://docs.camunda.io/docs/components/modeler/bpmn/error-events/) from a job handler — for example, to trigger an error boundary event — raise `JobError`:
 
-<!-- snippet:ReadmeBpmnError -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeBpmnError -->
 ```python
 from camunda_orchestration_sdk import ConnectedJobContext, JobError
 
@@ -625,7 +628,7 @@ The `error_code` must match the error code defined on a BPMN error catch event i
 
 When a job worker handles a [user task listener](https://docs.camunda.io/docs/components/concepts/user-task-listeners/), it can correct task properties (assignee, due date, candidate groups, etc.) as part of the completion. Return a `JobCompletionRequest` with a `result` containing `JobResultCorrections`:
 
-<!-- snippet:ReadmeJobCorrections -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeJobCorrections -->
 ```python
 from camunda_orchestration_sdk import ConnectedJobContext
 from camunda_orchestration_sdk.models import (
@@ -648,7 +651,7 @@ async def validate_task(job: ConnectedJobContext) -> JobCompletionRequest:
 
 To deny a task completion (reject the work), set `denied=True`:
 
-<!-- snippet:ReadmeJobCorrectionsDenied -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeJobCorrectionsDenied -->
 ```python
 async def review_task(job: ConnectedJobContext) -> JobCompletionRequest:
     return JobCompletionRequest(
@@ -675,7 +678,7 @@ Omitting an attribute or passing `None` preserves the persisted value. This work
 
 The SDK raises typed exceptions for API errors. Each HTTP error status code has a corresponding exception class (e.g. `BadRequestError` for 400, `NotFoundError` for 404). Every exception carries the `operation_id` of the method that raised it:
 
-<!-- snippet:ReadmeErrorHandling -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeErrorHandling -->
 ```python
 from camunda_orchestration_sdk import CamundaClient, ProcessCreationByKey, ProcessDefinitionKey
 from camunda_orchestration_sdk.errors import BadRequestError
@@ -707,7 +710,7 @@ Pass a `logger=` argument to `CamundaClient` or `CamundaAsyncClient`. The logger
 
 **stdlib `logging`:**
 
-<!-- snippet:ReadmeStdlibLogger -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeStdlibLogger -->
 ```python
 import logging
 
@@ -721,7 +724,7 @@ client = CamundaClient(logger=my_logger)
 
 **Custom logger object:**
 
-<!-- snippet:ReadmeCustomLogger -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeCustomLogger -->
 ```python
 from camunda_orchestration_sdk import CamundaClient
 
@@ -745,7 +748,7 @@ client = CamundaClient(logger=MyLogger())
 
 Pass an instance of `NullLogger` to silence all SDK output:
 
-<!-- snippet:ReadmeDisableLogging -->
+<!-- snippet-source: examples/readme.py | regions: ReadmeDisableLogging -->
 ```python
 from camunda_orchestration_sdk import CamundaClient, NullLogger
 

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -437,3 +437,50 @@ async def readme_job_corrections_denied() -> None:
             ),
         )
     # endregion ReadmeJobCorrectionsDenied
+
+
+# ---------- Job Logger ----------
+
+
+async def readme_job_logger() -> None:
+    from camunda_orchestration_sdk import ConnectedJobContext
+
+    # region ReadmeJobLogger
+    async def handler(job: ConnectedJobContext) -> dict[str, object]:
+        job.log.info(f"Starting work on {job.job_key}")
+        # ... do work ...
+        job.log.debug("Work completed successfully")
+        return {"done": True}
+    # endregion ReadmeJobLogger
+
+
+# ---------- Execution Strategies ----------
+
+
+async def readme_execution_strategies() -> None:
+    from camunda_orchestration_sdk import CamundaAsyncClient, WorkerConfig
+
+    async with CamundaAsyncClient() as client:
+        # region ReadmeExecutionStrategies
+        from camunda_orchestration_sdk import SyncJobContext, JobContext
+
+        # Force thread pool for a sync handler (receives SyncJobContext)
+        def io_handler(job: SyncJobContext) -> dict[str, object]:
+            return {"done": True}
+
+        client.create_job_worker(
+            config=WorkerConfig(job_type="io-bound-task", job_timeout_milliseconds=30_000),
+            callback=io_handler,
+            execution_strategy="thread",
+        )
+
+        # Force process pool for CPU-heavy work (receives plain JobContext)
+        def cpu_handler(job: JobContext) -> dict[str, object]:
+            return {"computed": True}
+
+        client.create_job_worker(
+            config=WorkerConfig(job_type="image-processing", job_timeout_milliseconds=120_000),
+            callback=cpu_handler,
+            execution_strategy="process",
+        )
+        # endregion ReadmeExecutionStrategies

--- a/scripts/sync-readme-snippets.py
+++ b/scripts/sync-readme-snippets.py
@@ -2,19 +2,21 @@
 """
 Synchronize code snippets in README.md from compilable example files.
 
-Replaces code blocks between ``<!-- snippet:RegionName -->`` markers in
-README.md with the corresponding region-tagged code from examples/*.py.
+Replaces code blocks between snippet markers in README.md with the
+corresponding region-tagged code from examples/*.py.
 
 Usage:
     python3 scripts/sync-readme-snippets.py          # update README.md in-place
     python3 scripts/sync-readme-snippets.py --check   # CI mode: exit 1 if out of sync
 
 Region tags in .py files use ``# region RegionName`` ... ``# endregion RegionName``.
-Markers in README.md use ``<!-- snippet:RegionName -->`` before a fenced
-code block.  The script replaces everything between the opening and closing
-fences (inclusive) with freshly extracted content.
+Markers in README.md use the descriptive format::
 
-Composite regions: ``<!-- snippet:A+B -->`` concatenates multiple regions
+    <!-- snippet-source: examples/readme.py | regions: RegionName -->
+
+Legacy markers (``<!-- snippet:RegionName -->``) are auto-migrated.
+
+Composite regions: ``regions: A+B`` concatenates multiple regions
 separated by blank lines.
 """
 
@@ -57,20 +59,49 @@ def parse_region_tags(py_path: Path) -> dict[str, str]:
     return regions
 
 
-def load_all_regions() -> dict[str, str]:
-    """Load regions from all .py files under examples/."""
+def load_all_regions() -> tuple[dict[str, str], dict[str, str]]:
+    """Load regions from all .py files under examples/.
+
+    Returns (region_content, region_source) where region_source maps
+    region name -> relative source file path.
+    """
     all_regions: dict[str, str] = {}
+    region_source: dict[str, str] = {}
     for py_file in sorted(EXAMPLES_DIR.glob("*.py")):
-        all_regions.update(parse_region_tags(py_file))
-    return all_regions
+        rel = py_file.relative_to(REPO_ROOT).as_posix()
+        for name, content in parse_region_tags(py_file).items():
+            all_regions[name] = content
+            region_source[name] = rel
+    return all_regions, region_source
 
 
 # ---------------------------------------------------------------------------
 # README rewriting
 # ---------------------------------------------------------------------------
 
-# Matches: <!-- snippet:RegionName --> or <!-- snippet:Region1+Region2 -->
-SNIPPET_MARKER = re.compile(r"^<!--\s*snippet:([\w+]+)\s*-->$")
+# New descriptive format:
+#   <!-- snippet-source: examples/readme.py | regions: RegionName -->
+_NEW_MARKER = re.compile(
+    r"^<!--\s*snippet-source:\s*\S+\s*\|\s*regions:\s*([\w+]+)\s*-->$"
+)
+# Legacy format (for migration):
+#   <!-- snippet:RegionName -->
+_OLD_MARKER = re.compile(r"^<!--\s*snippet:([\w+]+)\s*-->$")
+
+# Exempt marker: <!-- snippet-exempt: reason -->
+_EXEMPT_MARKER = re.compile(r"^<!--\s*snippet-exempt:.*-->$")
+
+
+def _match_marker(line: str) -> re.Match[str] | None:
+    """Match either new or legacy snippet marker."""
+    return _NEW_MARKER.match(line) or _OLD_MARKER.match(line)
+
+
+def _build_marker(region_name: str, region_source: dict[str, str]) -> str:
+    """Build a descriptive snippet marker line for *region_name*."""
+    parts = region_name.split("+") if "+" in region_name else [region_name]
+    source_file = region_source.get(parts[0], "examples/?.py")
+    return f"<!-- snippet-source: {source_file} | regions: {region_name} -->"
 
 
 def resolve_region(name: str, regions: dict[str, str]) -> str | None:
@@ -84,8 +115,16 @@ def resolve_region(name: str, regions: dict[str, str]) -> str | None:
     return "\n\n".join(r for r in resolved if r)
 
 
-def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
+def sync_readme(
+    regions: dict[str, str],
+    region_source: dict[str, str],
+    *,
+    check: bool = False,
+) -> bool:
     """Replace snippet-marked code blocks in README.md.
+
+    Also upgrades legacy ``<!-- snippet:X -->`` markers to the new
+    ``<!-- snippet-source: file | regions: X -->`` format.
 
     Returns True if the file was (or would be) changed.
     """
@@ -97,10 +136,11 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
     changed = False
     missing: list[str] = []
     errors: list[str] = []
+    snippet_count = 0
 
     while i < len(lines):
         line = lines[i].rstrip("\n")
-        m = SNIPPET_MARKER.match(line.strip())
+        m = _match_marker(line.strip())
 
         if not m:
             out.append(lines[i])
@@ -116,8 +156,13 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
             i += 1
             continue
 
-        # Keep the marker line
-        out.append(lines[i])
+        snippet_count += 1
+
+        # Upgrade legacy marker to the new descriptive format
+        new_marker = _build_marker(region_name, region_source) + "\n"
+        if lines[i] != new_marker:
+            changed = True
+        out.append(new_marker)
         i += 1
 
         # Skip whitespace between marker and opening fence
@@ -173,19 +218,75 @@ def sync_readme(regions: dict[str, str], *, check: bool = False) -> bool:
 
     if changed:
         README_PATH.write_text(new_text, encoding="utf-8", newline="")
-        print(f"README.md updated ({sum(1 for line in out if SNIPPET_MARKER.match(line.strip()))} snippets synced)")
+        print(f"README.md updated ({snippet_count} snippets synced)")
     else:
         print("README.md is already up to date")
 
     return changed
 
 
+# ---------------------------------------------------------------------------
+# Un-injected code block detection
+# ---------------------------------------------------------------------------
+
+_CHECKED_LANGUAGES = {"python", "py"}
+
+
+def detect_uninjected_code_blocks(readme_path: Path) -> list[tuple[int, str]]:
+    """Find fenced code blocks in *readme_path* that use a checked language
+    but are NOT preceded by a snippet marker or exempt marker.
+
+    Returns a list of ``(line_number, fence_line)`` tuples (1-based).
+    """
+    text = readme_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    uninjected: list[tuple[int, str]] = []
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("```"):
+            continue
+        lang = stripped.removeprefix("```").strip().lower()
+        if lang not in _CHECKED_LANGUAGES:
+            continue
+        # Look backward for a snippet marker or exempt marker (skip blank lines)
+        prev = idx - 1
+        while prev >= 0 and lines[prev].strip() == "":
+            prev -= 1
+        if prev >= 0:
+            prev_stripped = lines[prev].strip()
+            if _match_marker(prev_stripped) or _EXEMPT_MARKER.match(prev_stripped):
+                continue
+        uninjected.append((idx + 1, stripped))
+
+    return uninjected
+
+
 def main() -> None:
     check = "--check" in sys.argv
-    regions = load_all_regions()
+    regions, region_source = load_all_regions()
     print(f"Loaded {len(regions)} regions from examples/*.py")
 
-    changed = sync_readme(regions, check=check)
+    changed = sync_readme(regions, region_source, check=check)
+
+    # Detect un-injected Python code blocks
+    uninjected = detect_uninjected_code_blocks(README_PATH)
+    if uninjected:
+        print(
+            f"\nWARNING: {len(uninjected)} Python code block(s) in README.md are NOT "
+            "snippet-injected (not type-checked):",
+            file=sys.stderr,
+        )
+        for lineno, fence in uninjected:
+            print(f"  line {lineno}: {fence}", file=sys.stderr)
+        if check:
+            print(
+                "\nAll Python code blocks must be injected from compilable examples in "
+                "examples/. Add a snippet marker above each block, or move the "
+                "code to examples/readme.py with region tags.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     if check and changed:
         sys.exit(1)


### PR DESCRIPTION
## Summary

Hardens the README snippet injection pipeline to address all three points from #67:

### 1. Descriptive snippet markers

Snippet markers now include the source file and region name(s):

```html
<!-- snippet-source: examples/readme.py | regions: ReadmeJobLogger -->
```

Legacy `<!-- snippet:RegionName -->` markers are automatically migrated on sync.

### 2. Build-time drift detection

Both `generate` and `generate-local` Makefile targets now run the sync script in `--check` mode. If a README code block has been directly edited and no longer matches its source snippet, the build fails with a clear diff.

### 3. Un-injected code block detection

The sync script scans for Python code blocks that lack a snippet marker. On `--check`, any un-injected blocks cause a build failure.

Blocks that intentionally can't be type-checked (pseudo-code, hypothetical APIs) are marked with `<!-- snippet-exempt: reason -->`.

### Changes

- **`scripts/sync-readme-snippets.py`** — Rewritten with descriptive marker format, legacy migration, un-injected block detection, and exempt marker support
- **`examples/readme.py`** — Added 2 new regions: `ReadmeJobLogger`, `ReadmeExecutionStrategies`
- **`README.md`** — All 25 snippet markers upgraded to descriptive format; 1 exempt marker added for serialization pseudo-code; 0 un-injected Python blocks remaining
- **`Makefile`** — `generate` and `generate-local` targets use `--check` mode

Closes #67