### PR TITLE
fix: inject default tenant ID into request body, not path params

### DIFF
--- a/generated/camunda_orchestration_sdk/client.py
+++ b/generated/camunda_orchestration_sdk/client.py
@@ -2029,11 +2029,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = create_tenant_cluster_variable_sync(**_kwargs)
@@ -2140,11 +2135,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = delete_tenant_cluster_variable_sync(**_kwargs)
@@ -2257,11 +2247,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = get_tenant_cluster_variable_sync(**_kwargs)
@@ -2452,11 +2437,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = update_tenant_cluster_variable_sync(**_kwargs)
@@ -2519,6 +2499,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = evaluate_conditionals_sync(**_kwargs)
@@ -2594,6 +2583,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = evaluate_decision_sync(**_kwargs)
@@ -3749,6 +3747,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = evaluate_expression_sync(**_kwargs)
@@ -6190,6 +6197,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = correlate_message_sync(**_kwargs)
@@ -6250,6 +6266,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = publish_message_sync(**_kwargs)
@@ -7081,6 +7106,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = create_process_instance_sync(**_kwargs)
@@ -8055,6 +8089,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = create_deployment_sync(**_kwargs)
@@ -9295,6 +9338,15 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = broadcast_signal_sync(**_kwargs)
@@ -9408,11 +9460,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = get_usage_metrics_sync(**_kwargs)
@@ -9470,11 +9517,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = assign_client_to_tenant_sync(**_kwargs)
@@ -9532,11 +9574,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = assign_group_to_tenant_sync(**_kwargs)
@@ -9593,11 +9630,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = assign_mapping_rule_to_tenant_sync(**_kwargs)
@@ -9654,11 +9686,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = assign_role_to_tenant_sync(**_kwargs)
@@ -9714,11 +9741,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = assign_user_to_tenant_sync(**_kwargs)
@@ -9825,11 +9847,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = delete_tenant_sync(**_kwargs)
@@ -9880,11 +9897,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = get_tenant_sync(**_kwargs)
@@ -9943,11 +9955,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = search_clients_for_tenant_sync(**_kwargs)
@@ -10007,11 +10014,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = search_group_ids_for_tenant_sync(**_kwargs)
@@ -10071,11 +10073,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = search_mapping_rules_for_tenant_sync(**_kwargs)
@@ -10135,11 +10132,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = search_roles_for_tenant_sync(**_kwargs)
@@ -10254,11 +10246,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = search_users_for_tenant_sync(**_kwargs)
@@ -10316,11 +10303,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = unassign_client_from_tenant_sync(**_kwargs)
@@ -10379,11 +10361,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = unassign_group_from_tenant_sync(**_kwargs)
@@ -10440,11 +10417,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = unassign_mapping_rule_from_tenant_sync(**_kwargs)
@@ -10503,11 +10475,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = unassign_role_from_tenant_sync(**_kwargs)
@@ -10565,11 +10532,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = unassign_user_from_tenant_sync(**_kwargs)
@@ -10624,11 +10586,6 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         self._bp.acquire()
         try:
             _result = update_tenant_sync(**_kwargs)
@@ -13009,11 +12966,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await create_tenant_cluster_variable_asyncio(**_kwargs)
@@ -13120,11 +13072,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await delete_tenant_cluster_variable_asyncio(**_kwargs)
@@ -13237,11 +13184,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await get_tenant_cluster_variable_asyncio(**_kwargs)
@@ -13432,11 +13374,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await update_tenant_cluster_variable_asyncio(**_kwargs)
@@ -13499,6 +13436,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await evaluate_conditionals_asyncio(**_kwargs)
@@ -13574,6 +13520,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await evaluate_decision_asyncio(**_kwargs)
@@ -14733,6 +14688,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await evaluate_expression_asyncio(**_kwargs)
@@ -17182,6 +17146,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await correlate_message_asyncio(**_kwargs)
@@ -17242,6 +17215,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await publish_message_asyncio(**_kwargs)
@@ -18079,6 +18061,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await create_process_instance_asyncio(**_kwargs)
@@ -19053,6 +19044,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await create_deployment_asyncio(**_kwargs)
@@ -20305,6 +20305,15 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and (
+                "tenantId" not in _body or _body["tenantId"] is None
+            ):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await broadcast_signal_asyncio(**_kwargs)
@@ -20420,11 +20429,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await get_usage_metrics_asyncio(**_kwargs)
@@ -20482,11 +20486,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await assign_client_to_tenant_asyncio(**_kwargs)
@@ -20544,11 +20543,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await assign_group_to_tenant_asyncio(**_kwargs)
@@ -20605,11 +20599,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await assign_mapping_rule_to_tenant_asyncio(**_kwargs)
@@ -20668,11 +20657,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await assign_role_to_tenant_asyncio(**_kwargs)
@@ -20730,11 +20714,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await assign_user_to_tenant_asyncio(**_kwargs)
@@ -20841,11 +20820,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await delete_tenant_asyncio(**_kwargs)
@@ -20896,11 +20870,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await get_tenant_asyncio(**_kwargs)
@@ -20959,11 +20928,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await search_clients_for_tenant_asyncio(**_kwargs)
@@ -21023,11 +20987,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await search_group_ids_for_tenant_asyncio(**_kwargs)
@@ -21087,11 +21046,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await search_mapping_rules_for_tenant_asyncio(**_kwargs)
@@ -21151,11 +21105,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await search_roles_for_tenant_asyncio(**_kwargs)
@@ -21270,11 +21219,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await search_users_for_tenant_asyncio(**_kwargs)
@@ -21332,11 +21276,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await unassign_client_from_tenant_asyncio(**_kwargs)
@@ -21395,11 +21334,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await unassign_group_from_tenant_asyncio(**_kwargs)
@@ -21456,11 +21390,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await unassign_mapping_rule_from_tenant_asyncio(**_kwargs)
@@ -21519,11 +21448,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await unassign_role_from_tenant_asyncio(**_kwargs)
@@ -21581,11 +21505,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await unassign_user_from_tenant_asyncio(**_kwargs)
@@ -21640,11 +21559,6 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
-        _tid = _kwargs.get("tenant_id")
-        if (
-            _tid is None or _tid is UNSET
-        ) and self.configuration.CAMUNDA_TENANT_ID is not None:
-            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID
         await self._bp.acquire()
         try:
             _result = await update_tenant_asyncio(**_kwargs)

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -1,8 +1,9 @@
 import ast
+import json
 import os
 from pathlib import Path
 import re
-from typing import cast
+from typing import Any, cast
 
 # Methods that must bypass backpressure gating (drain work / complete execution).
 _BP_EXEMPT_METHODS: frozenset[str] = frozenset(
@@ -409,11 +410,86 @@ def get_imports_and_signature(
     return adjusted_imports, sync_func, async_func
 
 
-def generate_flat_client(package_path: Path) -> None:
+# Template for body tenant injection code.  Handles both attrs model objects
+# (tenant_id attribute, snake_case) and dict-like bodies (tenantId key, camelCase).
+_BODY_TENANT_INJECTION = """
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_ID is not None:
+            if hasattr(_body, "tenant_id"):
+                if _body.tenant_id is None or _body.tenant_id is UNSET:
+                    _body.tenant_id = self.configuration.CAMUNDA_TENANT_ID
+            elif isinstance(_body, dict) and ("tenantId" not in _body or _body["tenantId"] is None):
+                _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID"""
+
+
+def _compute_body_tenant_ops(spec_path: Path | None) -> set[str]:
+    """Return snake_case method names for operations with optional tenantId in request body.
+
+    These are 'tenant-as-context' operations where the SDK should inject the
+    configured default tenant ID into the body when the caller does not supply one.
+    Path-param tenant IDs (tenant-as-subject) are NOT included — those identify
+    which tenant to operate on and must always be provided explicitly.
+    """
+    if spec_path is None or not spec_path.exists():
+        return set()
+
+    with open(spec_path, "r", encoding="utf-8") as f:
+        if spec_path.suffix == ".json":
+            spec: dict[str, Any] = json.load(f)
+        else:
+            import yaml
+            spec = yaml.safe_load(f)
+
+    def resolve_ref(ref: str) -> dict[str, Any]:
+        parts = ref.lstrip("#/").split("/")
+        node: Any = spec
+        for p in parts:
+            node = node[p]
+        return cast(dict[str, Any], node)
+
+    def has_optional_tenant_id(schema: dict[str, Any], depth: int = 0) -> bool:
+        if depth > 5:
+            return False
+        if "$ref" in schema:
+            return has_optional_tenant_id(resolve_ref(schema["$ref"]), depth + 1)
+        props: dict[str, Any] = schema.get("properties", {})
+        if "tenantId" in props and "tenantId" not in schema.get("required", []):
+            return True
+        variants: list[dict[str, Any]] = schema.get("oneOf", []) + schema.get("anyOf", [])
+        for variant in variants:
+            if has_optional_tenant_id(variant, depth + 1):
+                return True
+        return False
+
+    ops: set[str] = set()
+    paths: dict[str, Any] = spec.get("paths", {})
+    for _path, methods in paths.items():
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            op_id: str = op.get("operationId", "")
+            body: dict[str, Any] = op.get("requestBody", {}).get("content", {})
+            for _ct, ct_data in body.items():
+                schema: dict[str, Any] = ct_data.get("schema", {})
+                if has_optional_tenant_id(schema):
+                    # Convert camelCase operationId to snake_case method name
+                    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", op_id)
+                    snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+                    ops.add(snake)
+                    break
+
+    if ops:
+        print(f"[flatten-client] body-tenant-injection ops ({len(ops)}): {sorted(ops)}")
+    return ops
+
+
+def generate_flat_client(package_path: Path, spec_path: Path | None = None) -> None:
     api_dir = package_path / "api"
     if not api_dir.exists():
         print(f"API directory not found at {api_dir}")
         return
+
+    body_tenant_ops = _compute_body_tenant_ops(spec_path)
 
     sync_methods: list[str] = []
     async_methods: list[str] = []
@@ -530,10 +606,10 @@ def generate_flat_client(package_path: Path) -> None:
                 docstring = ast.get_docstring(sync_func)
                 docstring_str = f'        """{docstring}"""\n' if docstring else ""
 
-                has_tenant_id = any(arg.arg == "tenant_id" for arg in new_args + new_kwonlyargs)
-                tenant_id_injection = ""
-                if has_tenant_id:
-                    tenant_id_injection = '\n        _tid = _kwargs.get("tenant_id")\n        if (_tid is None or _tid is UNSET) and self.configuration.CAMUNDA_TENANT_ID is not None:\n            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID'
+                # Body-tenant injection: for operations where tenantId is an optional
+                # field in the request body (tenant-as-context), inject the configured
+                # default tenant ID into the body model when the caller omits it.
+                tenant_id_injection = _BODY_TENANT_INJECTION if method_name in body_tenant_ops else ""
 
                 if method_name in _BP_EXEMPT_METHODS:
                     sync_methods.append(f"""
@@ -630,10 +706,8 @@ def generate_flat_client(package_path: Path) -> None:
                 docstring = ast.get_docstring(async_func)
                 docstring_str = f'        """{docstring}"""\n' if docstring else ""
 
-                has_tenant_id = any(arg.arg == "tenant_id" for arg in new_args + new_kwonlyargs)
-                tenant_id_injection = ""
-                if has_tenant_id:
-                    tenant_id_injection = '\n        _tid = _kwargs.get("tenant_id")\n        if (_tid is None or _tid is UNSET) and self.configuration.CAMUNDA_TENANT_ID is not None:\n            _kwargs["tenant_id"] = self.configuration.CAMUNDA_TENANT_ID'
+                # Body-tenant injection: same logic as sync methods
+                tenant_id_injection = _BODY_TENANT_INJECTION if method_name in body_tenant_ops else ""
 
                 if method_name in _BP_EXEMPT_METHODS:
                     async_methods.append(f"""
@@ -1230,10 +1304,13 @@ def run(context: dict[str, str]) -> None:
     if not package_dir.exists():
         print(f"Could not find package directory in {out_dir}")
         return
-    generate_flat_client(package_dir)
+    spec_path_str = context.get("bundled_spec_path", "")
+    spec_path = Path(spec_path_str) if spec_path_str else None
+    generate_flat_client(package_dir, spec_path)
 
 
 if __name__ == "__main__":
     base_dir = Path(__file__).parent.parent.parent
     package_dir = base_dir / "generated" / "camunda_orchestration_sdk"
-    generate_flat_client(package_dir)
+    spec_path = base_dir / "external-spec" / "bundled" / "rest-api.bundle.json"
+    generate_flat_client(package_dir, spec_path if spec_path.exists() else None)


### PR DESCRIPTION
## Summary

Fixes the tenant ID injection in `CamundaClient` to inject into **request body fields** (tenant-as-context) instead of **path parameters** (tenant-as-subject).

## Problem

The `0900_flatten_client.py` hook used a blanket check for any method with a `tenant_id` parameter, injecting `CAMUNDA_TENANT_ID` into `_kwargs["tenant_id"]` regardless of where the parameter appears in the API:

- **22 path-param operations** (e.g., `delete_tenant`, `assign_user_to_tenant`) — incorrectly received auto-injected tenant IDs, changing which tenant was being operated on
- **1 query-param operation** (`get_usage_metrics`) — incorrectly had the filter auto-populated
- **8 body-param operations** (e.g., `broadcast_signal`, `correlate_message`) — never received injection because `tenantId` is a field inside the `data` model, not a method parameter

## Fix

- Read the bundled OpenAPI spec at hook time to identify the 8 operations with optional `tenantId` in their request body schema (including `oneOf`/`anyOf` variants)
- Inject into the body model's `tenant_id` attribute instead of `_kwargs["tenant_id"]`
- Handle both attrs model objects and dict-like bodies
- Preserve explicitly provided tenant IDs (no overwrite)

## Operations that now receive body tenant injection

`broadcast_signal`, `correlate_message`, `create_deployment`, `create_process_instance`, `evaluate_conditionals`, `evaluate_decision`, `evaluate_expression`, `publish_message`

This matches the JS SDK's behavior exactly.

## Cross-SDK conformance test results

| SDK | Before | After |
|---|---|---|
| JS | 32/32 ✅ | 32/32 ✅ |
| Python | 0/32 ❌ | 31/32 ✅ |
| C# | 31/32 | 31/32 |

The remaining failure is `createDeployment` (multipart endpoint — same gap as C#, tracked separately).

## Verification

- `make generate` — 0 pyright errors
- 135 acceptance tests pass
- README snippets in sync

Closes #70