### PR TITLE
docs: update snippet format and add README examples to CONTRIBUTING

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,14 +127,17 @@ Code blocks in `README.md` are **injected from compilable example files** — do
 ### How it works
 
 1. Wrap code in `examples/readme.py` with `# region RegionName` / `# endregion RegionName` tags.
-2. In `README.md`, place `<!-- snippet:RegionName -->` immediately before the fenced code block.
+2. In `README.md`, place `<!-- snippet-source: examples/readme.py | regions: RegionName -->` immediately before the fenced code block.
 3. Run `python3 scripts/sync-readme-snippets.py` to update README (or the build does it automatically).
-4. Composite regions: `<!-- snippet:A+B -->` concatenates regions A and B separated by a blank line.
+4. Composite regions: `<!-- snippet-source: examples/readme.py | regions: A+B -->` concatenates regions A and B separated by a blank line.
+5. Exempt blocks: use `<!-- snippet-exempt: reason -->` above a code block to exclude it from injection enforcement (e.g. pseudo-code).
+
+The script auto-upgrades legacy `<!-- snippet:Name -->` markers to the new descriptive format.
 
 ### Adding or updating a README example
 
 1. Add/edit the region-tagged code in `examples/readme.py`.
-2. Add/verify the `<!-- snippet:RegionName -->` marker in `README.md`.
+2. Add/verify the `<!-- snippet-source: examples/readme.py | regions: RegionName -->` marker in `README.md`.
 3. Run `python3 scripts/sync-readme-snippets.py` to sync.
 4. Run `uv run pyright` to confirm the example type-checks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,30 @@ make itest
 - `make clean` – remove the `generated/` directory
 - `make clean_spec` – remove the `.openapi-cache/` directory
 - `make clean-docs` – remove generated documentation
+
+### README Code Examples
+
+Code blocks in `README.md` are **injected from compilable example files** — do not edit them inline.
+
+- **Source of truth**: `examples/readme.py` (type-checked by pyright during build)
+- **Sync script**: `scripts/sync-readme-snippets.py`
+- **CI gate**: `python3 scripts/sync-readme-snippets.py --check` (fails if README is out of sync)
+
+**How it works:**
+
+1. Wrap code in `examples/readme.py` with `# region RegionName` / `# endregion RegionName` tags.
+2. In `README.md`, place `<!-- snippet-source: examples/readme.py | regions: RegionName -->` immediately before the fenced code block.
+3. Run `python3 scripts/sync-readme-snippets.py` to update README (or the build does it automatically).
+4. Composite regions: `<!-- snippet-source: examples/readme.py | regions: A+B -->` concatenates regions A and B separated by a blank line.
+5. Exempt blocks: use `<!-- snippet-exempt: reason -->` above a code block to exclude it from injection enforcement (e.g. pseudo-code).
+
+The script auto-upgrades legacy `<!-- snippet:Name -->` markers to the new descriptive format.
+
+**Adding a new README example:**
+
+1. Add/edit the region-tagged code in `examples/readme.py`.
+2. Add/verify the `<!-- snippet-source: examples/readme.py | regions: RegionName -->` marker in `README.md`.
+3. Run `python3 scripts/sync-readme-snippets.py` to sync.
+4. Run `uv run pyright` to confirm the example type-checks.
+
+**Never edit a snippet-marked code block directly in README.md** — it will be overwritten on the next sync.


### PR DESCRIPTION
The contributor documentation was out of date with the actual snippet injection implementation.

### Changes

**copilot-instructions.md** —
```
```

**CONTRIBUTING.md** — added a complete 'README Code Examples' section. This workflow was previously only documented in copilot-instructions.md and was completely absent from the contributor guide.

All 24 markers in README.md already use the new format. The sync script auto-upgrades legacy markers.