### PR TITLE
docs: add 'prefer ergonomic helpers' guideline to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,6 +138,14 @@ A test that only covers the exact instance provides weaker protection: the same 
 
 ## README Code Examples
 
+### API spec examples: prefer ergonomic helpers
+
+The `examples/operation-map.json` file maps OpenAPI `operationId`s to example regions that are displayed in the Camunda docs API reference (via `docusaurus-plugin-openapi-docs`).
+
+When an ergonomic helper method exists for a generated operation, the operation-map entry **must** point to the helper — not to the raw generated method. Users should see the best developer experience by default.
+
+Example: `create_deployment` maps to `DeployResources` (`deploy_resources_from_files` helper) instead of the raw `create_deployment` (requires manual multipart form construction). This preference is consistent across all three SDK repos (C#, TypeScript, Python).
+
 Code blocks in `README.md` are **injected from compilable example files** — do not edit them inline.
 
 - **Source of truth**: `examples/readme.py` (type-checked by pyright during build)


### PR DESCRIPTION
## Summary

Adds an "API spec examples: prefer ergonomic helpers" section to `copilot-instructions.md` to make explicit the preference for ergonomic helper methods over raw generated methods in `operation-map.json` entries.

Python's operation-map already correctly uses `deploy_resources_from_files` for `create_deployment` — no operation-map change needed. This PR just documents the guideline.

Consistent with matching PRs on the C# and TypeScript SDK repos.