### PR TITLE
fix: add missing searchResources example and fix get_resource_content pyright error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Run tests (Unit and Integration)
         run: make itest
 
+      - name: Run type checker
+        if: matrix.python-version == '3.12'
+        run: make typecheck
+
       - name: Check SDK Example Coverage
         if: matrix.python-version == '3.12'
         run: python scripts/check_example_coverage.py
@@ -120,6 +124,3 @@ jobs:
 
       - name: Check docs links
         run: make docs-link-check
-
-      - name: Run type checker
-        run: make typecheck

--- a/examples/admin_operations.py
+++ b/examples/admin_operations.py
@@ -31,6 +31,7 @@ from camunda_orchestration_sdk import (
     JobWorkerStatisticsFilter,
     JobWorkerStatisticsQuery,
     MessageSubscriptionSearchQuery,
+    ResourceSearchQuery,
     TenantId,
     Unset,
     UpdateClusterVariableRequest,
@@ -335,8 +336,22 @@ def get_resource_content_example() -> None:
 
     content = client.get_resource_content(resource_key="123456")
 
-    print(f"Content length: {len(content)}")
+    print(f"Content: {content}")
 # endregion GetResourceContent
+
+
+# region SearchResources
+def search_resources_example() -> None:
+    client = CamundaClient()
+
+    result = client.search_resources(
+        data=ResourceSearchQuery(),
+    )
+
+    if not isinstance(result.items, Unset):
+        for resource in result.items:
+            print(f"Resource: {resource.resource_name}")
+# endregion SearchResources
 
 
 # region GetUsageMetrics

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1217,6 +1217,13 @@
             "label": "Get resource content"
         }
     ],
+    "search_resources": [
+        {
+            "file": "admin_operations.py",
+            "region": "SearchResources",
+            "label": "Search resources"
+        }
+    ],
     "get_usage_metrics": [
         {
             "file": "admin_operations.py",


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures:

1. **Missing `searchResources` example** — the upstream spec added `POST /resources/search` (`searchResources` operationId), causing the `check_example_coverage.py` gate to fail on the Python 3.12 matrix row.

2. **`len(content)` pyright error** — `get_resource_content` returns `str`, not `File`, so `len(content)` worked at runtime but `content.file_name` (attempted fix) failed pyright. Changed to `print(f"Content: {content}")`.

### Changes

- Added `SearchResources` example region in `examples/admin_operations.py`
- Added `search_resources` entry in `examples/operation-map.json`
- Added `ResourceSearchQuery` import
- Fixed `get_resource_content` example to use `str` return type correctly

### CI fix: move `make typecheck` to test job

The `lint` job previously ran `make typecheck` (pyright) against the **committed** generated code, which doesn't include `ResourceSearchQuery` or `search_resources` (added upstream). This caused pyright errors for any example that references types/methods not yet in the committed `generated/` directory.

Moved `make typecheck` into the `test` job (gated to `python-version == '3.12'`), which runs **after** `make itest` — and `make itest` depends on `make generate`, so pyright now checks freshly generated code. The `lint` job retains ruff, README snippet checks, config reference checks, and docs link checks.