### PR TITLE
fix: backport spec-injection identifier guard (SFD-214) to stable/9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      # Default is main. Temporary override options:
+      # Default is stable/8.9 for this branch (pinned to Camunda 8.9 spec).
+      # Temporary override options:
       # - Repo variable: SPEC_REF_OVERRIDE
       # - Manual run: workflow_dispatch input spec_ref
-      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
+      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
       SPEC_REF_OVERRIDE_ACK: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
       SPEC_REF_OVERRIDE_EXPIRES: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
     strategy:
@@ -37,7 +38,9 @@ jobs:
           set -euo pipefail
           echo "SPEC_REF=${SPEC_REF}"
 
-          if [[ "${SPEC_REF}" != "main" ]]; then
+          # stable/8.9 is the expected default for this branch — only guard
+          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
+          if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
             if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
               echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."
               exit 1

--- a/examples/admin_operations.py
+++ b/examples/admin_operations.py
@@ -335,7 +335,7 @@ def get_resource_content_example() -> None:
 
     content = client.get_resource_content(resource_key="123456")
 
-    print(f"Content length: {len(content)}")
+    print(f"Content: {content}")
 # endregion GetResourceContent
 
 

--- a/generate.py
+++ b/generate.py
@@ -76,6 +76,10 @@ def load_hooks(hooks_dir: Path) -> list[Callable[[dict[str, str]], None]]:
     hooks: list[Callable[[dict[str, str]], None]] = []
     if not hooks_dir.exists():
         return hooks
+    # Make sibling modules (e.g. _identifier_guard) importable by all hooks.
+    hooks_dir_str = str(hooks_dir.resolve())
+    if hooks_dir_str not in sys.path:
+        sys.path.insert(0, hooks_dir_str)
     for hook_file in sorted(hooks_dir.glob("*.py")):
         spec = importlib.util.spec_from_file_location(hook_file.stem, hook_file)
         if spec and spec.loader:

--- a/generate.py
+++ b/generate.py
@@ -79,7 +79,7 @@ def load_hooks(hooks_dir: Path) -> list[Callable[[dict[str, str]], None]]:
     # Make sibling modules (e.g. _identifier_guard) importable by all hooks.
     hooks_dir_str = str(hooks_dir.resolve())
     if hooks_dir_str not in sys.path:
-        sys.path.insert(0, hooks_dir_str)
+        sys.path.append(hooks_dir_str)
     for hook_file in sorted(hooks_dir.glob("*.py")):
         spec = importlib.util.spec_from_file_location(hook_file.stem, hook_file)
         if spec and spec.loader:

--- a/hooks/post_gen/0150_annotate_deprecated_enums.py
+++ b/hooks/post_gen/0150_annotate_deprecated_enums.py
@@ -9,8 +9,16 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Any
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_version_string, safe_py_identifier
 
 
 def _snake(name: str) -> str:
@@ -29,6 +37,11 @@ def _patch_enum_file(
 
     content = file_path.read_text(encoding="utf-8")
     original = content
+
+    # Validate all spec-controlled values before any interpolation
+    for m in deprecated_members:
+        safe_py_identifier(m["name"], "deprecated enum member name")
+        safe_version_string(m["deprecatedInVersion"], "deprecatedInVersion")
 
     deprecated_map = {m["name"]: m["deprecatedInVersion"] for m in deprecated_members}
 

--- a/hooks/post_gen/0150_annotate_deprecated_enums.py
+++ b/hooks/post_gen/0150_annotate_deprecated_enums.py
@@ -18,7 +18,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_version_string, safe_py_identifier
+from _identifier_guard import safe_version_string, safe_py_identifier  # noqa: E402
 
 
 def _snake(name: str) -> str:

--- a/hooks/post_gen/0150_annotate_deprecated_enums.py
+++ b/hooks/post_gen/0150_annotate_deprecated_enums.py
@@ -9,16 +9,10 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from pathlib import Path
 from typing import Any
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_version_string, safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_version_string, safe_py_identifier
 
 
 def _snake(name: str) -> str:

--- a/hooks/post_gen/0200_raise_exceptions.py
+++ b/hooks/post_gen/0200_raise_exceptions.py
@@ -1,10 +1,18 @@
 import ast
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_py_identifier
 
 
 def _status_class_name(code: int) -> str:
@@ -479,6 +487,7 @@ def modify_api_file(file_path: Path, *, spec: dict[str, Any]) -> None:
     modified = False
 
     module_stem = Path(file_path).stem
+    safe_py_identifier(module_stem, "API endpoint module name")
     status_type_map = _extract_status_type_map(tree)
     error_codes = sorted([c for c in status_type_map.keys() if not (200 <= c < 300)])
 

--- a/hooks/post_gen/0200_raise_exceptions.py
+++ b/hooks/post_gen/0200_raise_exceptions.py
@@ -1,18 +1,12 @@
 import ast
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Any, cast
 
 import yaml
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_py_identifier
 
 
 def _status_class_name(code: int) -> str:

--- a/hooks/post_gen/0200_raise_exceptions.py
+++ b/hooks/post_gen/0200_raise_exceptions.py
@@ -12,7 +12,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_py_identifier
+from _identifier_guard import safe_py_identifier  # noqa: E402
 
 
 def _status_class_name(code: int) -> str:

--- a/hooks/post_gen/0700_generate_semantic_types.py
+++ b/hooks/post_gen/0700_generate_semantic_types.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
 import yaml
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_py_identifier, safe_py_identifiers, safe_numeric_value
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {
@@ -91,6 +99,7 @@ def _emit_semantic_types_py(
     all_exported_names: List[str] = []
 
     for alias_name, info in sorted(aliases.items()):
+        safe_py_identifier(alias_name, "semantic type alias name")
         base = info.get("type", "string")
         py_base = {
             "string": "str",
@@ -138,14 +147,16 @@ def _emit_semantic_types_py(
         # Numeric constraints
         if py_base in {"int", "float"}:
             if "minimum" in constraints:
-                class_def.append(f'\t\tif value < {constraints["minimum"]}:\n')
+                min_val = safe_numeric_value(constraints["minimum"], "minimum")
+                class_def.append(f'\t\tif value < {min_val}:\n')
                 class_def.append(
-                    f'\t\t\traise ValueError(f"{alias_name} smaller than minimum {constraints["minimum"]}, got {{value!r}}")\n'
+                    f'\t\t\traise ValueError(f"{alias_name} smaller than minimum {min_val}, got {{value!r}}")\n'
                 )
             if "maximum" in constraints:
-                class_def.append(f'\t\tif value > {constraints["maximum"]}:\n')
+                max_val = safe_numeric_value(constraints["maximum"], "maximum")
+                class_def.append(f'\t\tif value > {max_val}:\n')
                 class_def.append(
-                    f'\t\t\traise ValueError(f"{alias_name} larger than maximum {constraints["maximum"]}, got {{value!r}}")\n'
+                    f'\t\t\traise ValueError(f"{alias_name} larger than maximum {max_val}, got {{value!r}}")\n'
                 )
         
         # Enum constraints
@@ -167,6 +178,8 @@ def _emit_semantic_types_py(
     # Emit union type aliases (e.g. ScopeKey = ProcessInstanceKey | ElementInstanceKey)
     if union_aliases:
         for union_name, branch_names in sorted(union_aliases.items()):
+            safe_py_identifier(union_name, "union alias name")
+            safe_py_identifiers(branch_names, "union branch name")
             func_name = _snake(f"lift_{union_name}")
             try_func_name = _snake(f"try_lift_{union_name}")
             all_exported_names.extend([union_name, func_name, try_func_name])

--- a/hooks/post_gen/0700_generate_semantic_types.py
+++ b/hooks/post_gen/0700_generate_semantic_types.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
 import yaml
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_py_identifier, safe_py_identifiers, safe_numeric_value  # noqa: E402
+from _identifier_guard import safe_py_identifier, safe_py_identifiers, safe_numeric_value
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {

--- a/hooks/post_gen/0700_generate_semantic_types.py
+++ b/hooks/post_gen/0700_generate_semantic_types.py
@@ -11,7 +11,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_py_identifier, safe_py_identifiers, safe_numeric_value
+from _identifier_guard import safe_py_identifier, safe_py_identifiers, safe_numeric_value  # noqa: E402
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {

--- a/hooks/post_gen/0800_generate_composite_alias_models.py
+++ b/hooks/post_gen/0800_generate_composite_alias_models.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 import yaml
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_py_identifier
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {

--- a/hooks/post_gen/0800_generate_composite_alias_models.py
+++ b/hooks/post_gen/0800_generate_composite_alias_models.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
 import yaml
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_py_identifier
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {
@@ -41,6 +49,9 @@ def _emit_array_alias_model(
 ) -> None:
     filename = models_dir / f"{_snake(alias)}.py"
 
+    # Validate spec-controlled identifiers before interpolation into Python source
+    safe_py_identifier(alias, "composite alias schema name")
+
     # Determine python base type for item
     item_type = item_schema.get("type", "string")
     py_item = {
@@ -53,6 +64,7 @@ def _emit_array_alias_model(
     # Use semantic type if available (e.g. Tag instead of str)
     semantic_type = item_schema.get("x-semantic-type")
     if isinstance(semantic_type, str):
+        safe_py_identifier(semantic_type, "x-semantic-type")
         py_item = semantic_type
 
     raw_pattern = item_schema.get("pattern") if item_type == "string" else None

--- a/hooks/post_gen/0800_generate_composite_alias_models.py
+++ b/hooks/post_gen/0800_generate_composite_alias_models.py
@@ -11,7 +11,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_py_identifier
+from _identifier_guard import safe_py_identifier  # noqa: E402
 
 # Unicode property escapes (ECMAScript) -> Python re equivalents
 _UNICODE_PROPERTY_MAP: Dict[str, str] = {

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -3,7 +3,15 @@ import json
 import os
 from pathlib import Path
 import re
+import sys
 from typing import Any, cast
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_docstring, safe_dotted_import_path, safe_py_identifier
 
 # Methods that must bypass backpressure gating (drain work / complete execution).
 _BP_EXEMPT_METHODS: frozenset[str] = frozenset(
@@ -542,6 +550,8 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None) -> N
             module_name = file[:-3]
             import_path = f".{'.'.join(rel_path.parts)}.{module_name}"
             method_name = module_name
+            safe_py_identifier(method_name, "endpoint method name")
+            safe_dotted_import_path(import_path, "endpoint import path")
 
             # Lift path parameter annotations from str to semantic types
             for func in [f for f in [sync_func, async_func] if f is not None]:
@@ -605,7 +615,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None) -> N
                     f" -> {ast.unparse(sync_func.returns)}" if sync_func.returns else ""
                 )
                 docstring = ast.get_docstring(sync_func)
-                docstring_str = f'        """{docstring}"""\n' if docstring else ""
+                docstring_str = f'        """{safe_docstring(docstring)}"""\n' if docstring else ""
 
                 # Body-tenant injection: for operations where tenantId is an optional
                 # field in the request body (tenant-as-context), inject the configured
@@ -705,7 +715,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None) -> N
                     else ""
                 )
                 docstring = ast.get_docstring(async_func)
-                docstring_str = f'        """{docstring}"""\n' if docstring else ""
+                docstring_str = f'        """{safe_docstring(docstring)}"""\n' if docstring else ""
 
                 # Body-tenant injection: same logic as sync methods
                 tenant_id_injection = _BODY_TENANT_INJECTION if method_name in body_tenant_ops else ""

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -3,15 +3,9 @@ import json
 import os
 from pathlib import Path
 import re
-import sys
 from typing import Any, cast
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_docstring, safe_dotted_import_path, safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_docstring, safe_dotted_import_path, safe_py_identifier
 
 # Methods that must bypass backpressure gating (drain work / complete execution).
 _BP_EXEMPT_METHODS: frozenset[str] = frozenset(

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -11,7 +11,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_docstring, safe_dotted_import_path, safe_py_identifier
+from _identifier_guard import safe_docstring, safe_dotted_import_path, safe_py_identifier  # noqa: E402
 
 # Methods that must bypass backpressure gating (drain work / complete execution).
 _BP_EXEMPT_METHODS: frozenset[str] = frozenset(

--- a/hooks/post_gen/1000_patch_semantic_types_in_models.py
+++ b/hooks/post_gen/1000_patch_semantic_types_in_models.py
@@ -10,7 +10,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_py_identifier
+from _identifier_guard import safe_py_identifier  # noqa: E402
 
 
 def _snake(name: str) -> str:

--- a/hooks/post_gen/1000_patch_semantic_types_in_models.py
+++ b/hooks/post_gen/1000_patch_semantic_types_in_models.py
@@ -1,8 +1,16 @@
 import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, cast
 
 import yaml
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_py_identifier
 
 
 def _snake(name: str) -> str:
@@ -29,6 +37,7 @@ def _extract_semantic_mappings(data: Any, mappings: Dict[str, str]) -> None:
                         prop_schema_dict = cast(dict[str, Any], prop_schema)
                         semantic_type = prop_schema_dict.get("x-semantic-type")
                         if isinstance(semantic_type, str):
+                            safe_py_identifier(semantic_type, "x-semantic-type")
                             mappings[prop_name] = semantic_type
                     # Recurse into properties
                     _extract_semantic_mappings(prop_schema, mappings)

--- a/hooks/post_gen/1000_patch_semantic_types_in_models.py
+++ b/hooks/post_gen/1000_patch_semantic_types_in_models.py
@@ -1,16 +1,10 @@
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, cast
 
 import yaml
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_py_identifier
 
 
 def _snake(name: str) -> str:

--- a/hooks/post_gen/1375_reexport_models.py
+++ b/hooks/post_gen/1375_reexport_models.py
@@ -19,7 +19,7 @@ _hooks_dir = str(Path(__file__).resolve().parent)
 if _hooks_dir not in sys.path:
     sys.path.insert(0, _hooks_dir)
 
-from _identifier_guard import safe_py_identifier
+from _identifier_guard import safe_py_identifier  # noqa: E402
 
 
 def _parse_all_names(init_path: Path) -> list[str]:

--- a/hooks/post_gen/1375_reexport_models.py
+++ b/hooks/post_gen/1375_reexport_models.py
@@ -11,15 +11,9 @@ from __future__ import annotations
 
 import ast
 import re
-import sys
 from pathlib import Path
 
-# Ensure sibling modules are importable
-_hooks_dir = str(Path(__file__).resolve().parent)
-if _hooks_dir not in sys.path:
-    sys.path.insert(0, _hooks_dir)
-
-from _identifier_guard import safe_py_identifier  # noqa: E402
+from _identifier_guard import safe_py_identifier
 
 
 def _parse_all_names(init_path: Path) -> list[str]:

--- a/hooks/post_gen/1375_reexport_models.py
+++ b/hooks/post_gen/1375_reexport_models.py
@@ -11,7 +11,15 @@ from __future__ import annotations
 
 import ast
 import re
+import sys
 from pathlib import Path
+
+# Ensure sibling modules are importable
+_hooks_dir = str(Path(__file__).resolve().parent)
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from _identifier_guard import safe_py_identifier
 
 
 def _parse_all_names(init_path: Path) -> list[str]:
@@ -86,6 +94,10 @@ def run(context: dict[str, str]) -> None:
     if not model_names:
         print("Warning: no model names found in models/__init__.py __all__")
         return
+
+    # Validate all model names before interpolation into import statements
+    for name in model_names:
+        safe_py_identifier(name, "model re-export name")
 
     init_text = init_file.read_text(encoding="utf-8")
 

--- a/hooks/post_gen/_identifier_guard.py
+++ b/hooks/post_gen/_identifier_guard.py
@@ -1,0 +1,120 @@
+"""Shared validation for spec-derived identifiers interpolated into generated Python source.
+
+All post-generation hooks that embed spec-controlled strings into Python code
+MUST validate them through these helpers before interpolation.
+
+This module prevents CWE-94 (Code Injection) by ensuring that spec-controlled
+values cannot escape their syntactic context in generated Python source.
+"""
+
+from __future__ import annotations
+
+import keyword
+import re
+
+# Use \Z (not $) to anchor at end-of-string.  $ allows a trailing \n
+# which would bypass the check and enable newline injection.
+_IDENTIFIER_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def safe_py_identifier(value: str, context: str = "") -> str:
+    """Validate that *value* is a safe Python identifier.
+
+    Raises ``ValueError`` if the value contains characters that could
+    escape an f-string interpolation context (newlines, quotes, etc.)
+    or is a Python keyword.
+    """
+    ctx = f" ({context})" if context else ""
+    if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"Spec-controlled value is not a safe Python identifier{ctx}: {value!r}"
+        )
+    if keyword.iskeyword(value):
+        raise ValueError(
+            f"Spec-controlled value is a Python keyword{ctx}: {value!r}"
+        )
+    return value
+
+
+def safe_py_identifiers(values: list[str], context: str = "") -> list[str]:
+    """Validate a list of values as safe Python identifiers."""
+    return [safe_py_identifier(v, context) for v in values]
+
+
+def safe_docstring(value: str | None) -> str:
+    """Sanitise a spec-derived string for interpolation inside triple-quoted docstrings.
+
+    Handles two escape vectors:
+    1. Embedded ``\"\"\"`` sequences that would terminate the docstring boundary.
+    2. Trailing backslashes that would escape the closing ``\"\"\"``, leaving
+       the docstring unterminated and potentially consuming subsequent code.
+    """
+    if value is None:
+        return ""
+    # Replace triple-quote sequences that would terminate the docstring
+    result = value.replace('"""', "'''")
+    # An odd number of trailing backslashes would escape the first " of the
+    # closing """, leaving the docstring unterminated.  Double the last
+    # backslash to make the count even.
+    stripped = result.rstrip("\\")
+    trailing = len(result) - len(stripped)
+    if trailing % 2 == 1:
+        result += "\\"
+    return result
+
+
+def safe_version_string(value: str, context: str = "") -> str:
+    """Validate that *value* is a safe version string (digits, dots, hyphens, alphanums).
+
+    Used for deprecatedInVersion and similar spec-metadata values that are
+    interpolated into comments and docstrings.
+    """
+    ctx = f" ({context})" if context else ""
+    # Use \Z (not $) to prevent trailing-newline bypass
+    if not isinstance(value, str) or not re.match(
+        r"\A[A-Za-z0-9._\-]+\Z", value
+    ):
+        raise ValueError(
+            f"Spec-controlled value is not a safe version string{ctx}: {value!r}"
+        )
+    return value
+
+
+def safe_numeric_value(value: object, context: str = "") -> int | float:
+    """Validate that *value* is a numeric type safe for direct interpolation.
+
+    Rejects strings and other types that could inject code when interpolated
+    into generated Python source via f-strings like ``f"if value < {minimum}:"``.
+    """
+    ctx = f" ({context})" if context else ""
+    if isinstance(value, bool):
+        raise ValueError(
+            f"Spec-controlled value is boolean, expected numeric{ctx}: {value!r}"
+        )
+    if isinstance(value, (int, float)):
+        return value
+    raise ValueError(
+        f"Spec-controlled value is not numeric{ctx}: {value!r}"
+    )
+
+
+def safe_dotted_import_path(value: str, context: str = "") -> str:
+    """Validate that *value* is a safe dotted Python import path.
+
+    Each segment between dots must be a valid Python identifier.
+    Leading dots (relative imports) are permitted.
+    """
+    ctx = f" ({context})" if context else ""
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Spec-controlled value is not a string{ctx}: {value!r}"
+        )
+    # Strip leading dots (relative import prefix)
+    stripped = value.lstrip(".")
+    if not stripped:
+        raise ValueError(
+            f"Spec-controlled import path has no module segments{ctx}: {value!r}"
+        )
+    for segment in stripped.split("."):
+        safe_py_identifier(segment, context)
+    return value

--- a/hooks/post_gen/_identifier_guard.py
+++ b/hooks/post_gen/_identifier_guard.py
@@ -18,7 +18,7 @@ import re
 _IDENTIFIER_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
-def safe_py_identifier(value: str, context: str = "") -> str:
+def safe_py_identifier(value: object, context: str = "") -> str:
     """Validate that *value* is a safe Python identifier.
 
     Raises ``ValueError`` if the value contains characters that could
@@ -64,7 +64,7 @@ def safe_docstring(value: str | None) -> str:
     return result
 
 
-def safe_version_string(value: str, context: str = "") -> str:
+def safe_version_string(value: object, context: str = "") -> str:
     """Validate that *value* is a safe version string (digits, dots, hyphens, alphanums).
 
     Used for deprecatedInVersion and similar spec-metadata values that are
@@ -103,7 +103,7 @@ def safe_numeric_value(value: object, context: str = "") -> int | float:
     )
 
 
-def safe_dotted_import_path(value: str, context: str = "") -> str:
+def safe_dotted_import_path(value: object, context: str = "") -> str:
     """Validate that *value* is a safe dotted Python import path.
 
     Each segment between dots must be a valid Python identifier.

--- a/hooks/post_gen/_identifier_guard.py
+++ b/hooks/post_gen/_identifier_guard.py
@@ -10,6 +10,7 @@ values cannot escape their syntactic context in generated Python source.
 from __future__ import annotations
 
 import keyword
+import math
 import re
 
 # Use \Z (not $) to anchor at end-of-string.  $ allows a trailing \n
@@ -92,6 +93,10 @@ def safe_numeric_value(value: object, context: str = "") -> int | float:
             f"Spec-controlled value is boolean, expected numeric{ctx}: {value!r}"
         )
     if isinstance(value, (int, float)):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"Spec-controlled value is non-finite, expected finite numeric{ctx}: {value!r}"
+            )
         return value
     raise ValueError(
         f"Spec-controlled value is not numeric{ctx}: {value!r}"

--- a/tests/acceptance/test_identifier_guard.py
+++ b/tests/acceptance/test_identifier_guard.py
@@ -7,7 +7,6 @@ that could escape their syntactic context in generated Python source (CWE-94).
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
 
 import pytest

--- a/tests/acceptance/test_identifier_guard.py
+++ b/tests/acceptance/test_identifier_guard.py
@@ -6,6 +6,7 @@ that could escape their syntactic context in generated Python source (CWE-94).
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 from pathlib import Path
 
@@ -202,6 +203,9 @@ class TestSafeNumericValue:
             (False, "boolean False"),
             (None, "None"),
             ([1], "list"),
+            (float("nan"), "NaN"),
+            (float("inf"), "positive infinity"),
+            (float("-inf"), "negative infinity"),
         ],
     )
     def test_rejects_non_numeric(self, value: object, description: str) -> None:
@@ -261,8 +265,13 @@ class TestNoHookInterpolatesUnsafeIdentifiers:
     @pytest.mark.parametrize("hook_file", HOOKS_REQUIRING_GUARD)
     def test_hook_imports_identifier_guard(self, hook_file: str) -> None:
         hook_path = Path(__file__).resolve().parents[2] / "hooks" / "post_gen" / hook_file
-        content = hook_path.read_text(encoding="utf-8")
-        assert "from _identifier_guard import" in content, (
+        source = hook_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=hook_file)
+        has_import = any(
+            isinstance(node, ast.ImportFrom) and node.module == "_identifier_guard"
+            for node in ast.walk(tree)
+        )
+        assert has_import, (
             f"{hook_file} does not import from _identifier_guard — "
             f"spec-controlled strings may be interpolated into Python source without validation"
         )

--- a/tests/acceptance/test_identifier_guard.py
+++ b/tests/acceptance/test_identifier_guard.py
@@ -1,0 +1,269 @@
+"""Tests for hooks/post_gen/_identifier_guard.py — spec-injection prevention.
+
+Validates that all identifier validation helpers reject spec-controlled strings
+that could escape their syntactic context in generated Python source (CWE-94).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the guard module from hooks/post_gen/
+_guard_path = Path(__file__).resolve().parents[2] / "hooks" / "post_gen" / "_identifier_guard.py"
+_spec = importlib.util.spec_from_file_location("_identifier_guard", _guard_path)
+assert _spec and _spec.loader
+_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guard)
+
+safe_py_identifier = _guard.safe_py_identifier
+safe_py_identifiers = _guard.safe_py_identifiers
+safe_docstring = _guard.safe_docstring
+safe_version_string = _guard.safe_version_string
+safe_numeric_value = _guard.safe_numeric_value
+safe_dotted_import_path = _guard.safe_dotted_import_path
+
+
+class TestSafePyIdentifier:
+    """Validate that safe_py_identifier rejects all non-identifier strings."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "ProcessInstanceKey",
+            "MyType",
+            "_private",
+            "a1",
+            "Foo_Bar_123",
+        ],
+    )
+    def test_accepts_valid_identifiers(self, value: str) -> None:
+        assert safe_py_identifier(value) == value
+
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            # Newline injection (primary attack vector from SFD-214)
+            ('PwnedKey = "dummy"\nimport os; os.system("x")\n_sink', "newline injection"),
+            # Quote injection
+            ('Foo"Bar', "double quote"),
+            ("Foo'Bar", "single quote"),
+            # Space injection
+            ("Foo Bar", "space"),
+            # Semicolon injection
+            ("Foo;Bar", "semicolon"),
+            # Parenthesis injection
+            ("Foo()", "parentheses"),
+            # Empty string
+            ("", "empty string"),
+            # Starts with digit
+            ("1Foo", "starts with digit"),
+            # Contains special characters
+            ("Foo$Bar", "dollar sign"),
+            ("Foo\tBar", "tab character"),
+            ("Foo\rBar", "carriage return"),
+            # Backslash injection
+            ("Foo\\nBar", "backslash-n"),
+        ],
+    )
+    def test_rejects_unsafe_identifiers(self, value: str, description: str) -> None:
+        with pytest.raises(ValueError, match="not a safe Python identifier"):
+            safe_py_identifier(value)
+
+    def test_rejects_trailing_newline_bypass(self) -> None:
+        """Regression: $ in regex allows trailing newline. Must use \\Z."""
+        with pytest.raises(ValueError, match="not a safe Python identifier"):
+            safe_py_identifier("Foo\n")
+
+    @pytest.mark.parametrize(
+        "keyword",
+        ["class", "def", "import", "return", "if", "for", "while", "try", "except"],
+    )
+    def test_rejects_python_keywords(self, keyword: str) -> None:
+        with pytest.raises(ValueError, match="Python keyword"):
+            safe_py_identifier(keyword)
+
+    def test_context_appears_in_error(self) -> None:
+        with pytest.raises(ValueError, match="x-semantic-type"):
+            safe_py_identifier("bad value", "x-semantic-type")
+
+
+class TestSafePyIdentifiers:
+    """Validate batch identifier validation."""
+
+    def test_accepts_valid_list(self) -> None:
+        result = safe_py_identifiers(["Foo", "Bar", "Baz"])
+        assert result == ["Foo", "Bar", "Baz"]
+
+    def test_rejects_any_invalid(self) -> None:
+        with pytest.raises(ValueError):
+            safe_py_identifiers(["Foo", "Bad Value", "Baz"])
+
+
+class TestSafeDocstring:
+    """Validate that safe_docstring escapes docstring-terminating sequences."""
+
+    def test_preserves_normal_text(self) -> None:
+        assert safe_docstring("Hello world") == "Hello world"
+
+    def test_escapes_triple_double_quotes(self) -> None:
+        result = safe_docstring('Foo """bar""" baz')
+        assert '"""' not in result
+
+    def test_preserves_triple_single_quotes(self) -> None:
+        """Triple single-quotes are safe inside triple double-quote delimiters."""
+        result = safe_docstring("Foo '''bar''' baz")
+        assert result == "Foo '''bar''' baz"
+
+    def test_handles_none(self) -> None:
+        assert safe_docstring(None) == ""
+
+    def test_sanitised_docstring_is_valid_python(self) -> None:
+        """Ensure a sanitised docstring can be embedded in triple-quoted string."""
+        malicious = 'Inject """\nimport os\nos.system("x")\n"""'
+        sanitised = safe_docstring(malicious)
+        # Construct a Python source with the sanitised docstring
+        source = f'def f():\n    """{sanitised}"""\n    pass\n'
+        # Must parse without error
+        compile(source, "<test>", "exec")
+
+    def test_trailing_backslash_does_not_escape_closing_quotes(self) -> None:
+        """Regression: trailing \\ escapes the first \" of closing \"\"\", breaking the docstring."""
+        result = safe_docstring("test\\")
+        source = f'def f():\n    """{result}"""\n    pass\n'
+        # Must parse without error — if trailing backslash isn't handled,
+        # the closing """ is escaped and the source fails to compile.
+        compile(source, "<test>", "exec")
+
+    def test_trailing_odd_backslashes_doubled(self) -> None:
+        """An odd number of trailing backslashes must be made even."""
+        result = safe_docstring("test\\\\\\")  # 3 trailing backslashes
+        source = f'def f():\n    """{result}"""\n    pass\n'
+        compile(source, "<test>", "exec")
+
+    def test_trailing_even_backslashes_preserved(self) -> None:
+        """An even number of trailing backslashes is already safe."""
+        result = safe_docstring("test\\\\")  # 2 trailing backslashes
+        assert result == "test\\\\"
+
+    def test_combined_attack_quotes_and_backslash(self) -> None:
+        """Combined attack: triple-quote preceded by backslash."""
+        malicious = 'Inject \\"""\nimport os\nos.system("x")'
+        sanitised = safe_docstring(malicious)
+        source = f'def f():\n    """{sanitised}"""\n    pass\n'
+        compile(source, "<test>", "exec")
+
+
+class TestSafeVersionString:
+    """Validate version string sanitisation."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["8.5", "8.5.0", "8.5.0-alpha1", "1.0.0", "v2.3.4"],
+    )
+    def test_accepts_valid_versions(self, value: str) -> None:
+        assert safe_version_string(value) == value
+
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            ('8.5"""\nimport os\n"""', "triple quote escape"),
+            ("8.5\nimport os", "newline injection"),
+            ("8.5; import os", "semicolon injection"),
+            ("", "empty string"),
+            ("8.5 or True", "space injection"),
+        ],
+    )
+    def test_rejects_unsafe_versions(self, value: str, description: str) -> None:
+        with pytest.raises(ValueError, match="not a safe version string"):
+            safe_version_string(value)
+
+    def test_rejects_trailing_newline_bypass(self) -> None:
+        """Regression: $ in regex allows trailing newline. Must use \\Z."""
+        with pytest.raises(ValueError, match="not a safe version string"):
+            safe_version_string("8.5\n")
+
+
+class TestSafeNumericValue:
+    """Validate numeric constraint guard — prevents string injection via minimum/maximum."""
+
+    @pytest.mark.parametrize("value", [0, 1, -1, 42, 3.14, -0.5, 1e10])
+    def test_accepts_valid_numbers(self, value: int | float) -> None:
+        assert safe_numeric_value(value) == value
+
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            ("0\nimport os\nos.system('x')\n#", "string with newline injection"),
+            ("42", "string that looks numeric"),
+            (True, "boolean True (subclass of int in Python)"),
+            (False, "boolean False"),
+            (None, "None"),
+            ([1], "list"),
+        ],
+    )
+    def test_rejects_non_numeric(self, value: object, description: str) -> None:
+        with pytest.raises(ValueError):
+            safe_numeric_value(value)
+
+
+class TestSafeDottedImportPath:
+    """Validate dotted import path guard for from-import statements."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            ".api.create_process_instance",
+            "..foo.bar",
+            ".module",
+            "package.module",
+        ],
+    )
+    def test_accepts_valid_paths(self, value: str) -> None:
+        assert safe_dotted_import_path(value) == value
+
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            (".api.bad name", "space in segment"),
+            (".api.import", "keyword segment"),
+            (".api.\nimport os", "newline injection"),
+            ("", "empty string"),
+            (".", "dots only"),
+        ],
+    )
+    def test_rejects_unsafe_paths(self, value: str, description: str) -> None:
+        with pytest.raises(ValueError):
+            safe_dotted_import_path(value)
+
+
+class TestNoHookInterpolatesUnsafeIdentifiers:
+    """Class-scoped regression guard: verify that all hooks that generate Python
+    source import and use the identifier guard.
+
+    This catches the defect CLASS (any hook that interpolates spec-controlled
+    strings without validation), not just the specific instances from SFD-214.
+    """
+
+    # All hooks that interpolate spec-controlled strings into Python source
+    HOOKS_REQUIRING_GUARD = [
+        "0150_annotate_deprecated_enums.py",
+        "0200_raise_exceptions.py",
+        "0700_generate_semantic_types.py",
+        "0800_generate_composite_alias_models.py",
+        "0900_flatten_client.py",
+        "1000_patch_semantic_types_in_models.py",
+        "1375_reexport_models.py",
+    ]
+
+    @pytest.mark.parametrize("hook_file", HOOKS_REQUIRING_GUARD)
+    def test_hook_imports_identifier_guard(self, hook_file: str) -> None:
+        hook_path = Path(__file__).resolve().parents[2] / "hooks" / "post_gen" / hook_file
+        content = hook_path.read_text(encoding="utf-8")
+        assert "from _identifier_guard import" in content, (
+            f"{hook_file} does not import from _identifier_guard — "
+            f"spec-controlled strings may be interpolated into Python source without validation"
+        )


### PR DESCRIPTION
## Backport of #121 to stable/9

Cherry-pick of the security fix PR #121 (`fix/spec-injection-identifier-guard`) to the `stable/9` branch.

### Security fix: SFD-214

Guards all spec-controlled identifiers interpolated into generated Python source code against code injection. Without these guards, a malicious OpenAPI spec could inject arbitrary Python code that executes during generation (CI RCE) and on every downstream `import` of the generated SDK.

### Changes

- `hooks/post_gen/_identifier_guard.py` (NEW): 6 guard functions — `safe_py_identifier`, `safe_py_identifiers`, `safe_docstring`, `safe_version_string`, `safe_numeric_value`, `safe_dotted_import_path`
- `generate.py`: Added hooks dir to `sys.path` so all hooks can import `_identifier_guard`
- 7 hooks modified to use guards instead of raw f-string interpolation
- `tests/acceptance/test_identifier_guard.py` (NEW): 82 tests including `ast.parse` guard-adoption check
- `examples/admin_operations.py`: Fixed `len(content)` → `print(f"Content: {content}")` for pyright

All commits cherry-picked cleanly from `fix/spec-injection-identifier-guard`.

### CI fix: pin SPEC_REF to stable/8.9

The `ci.yml` on `stable/9` defaulted `SPEC_REF` to `'main'`, so CI fetched the latest upstream spec (which now includes `searchResources` from Camunda 8.10). This caused the `check_example_coverage.py` gate to fail because `stable/9` doesn't have a `searchResources` example — and shouldn't, since it's pinned to 8.9.

Fixed by changing the CI default from `'main'` to `'stable/8.9'`, matching the Makefile default (`SPEC_REF ?= stable/8.9`). CI on this branch will now always fetch the 8.9 spec.