### PR TITLE
feat: add example coverage for 4 new operations

### DIFF
--- a/examples/admin_operations.py
+++ b/examples/admin_operations.py
@@ -18,6 +18,7 @@ from camunda_orchestration_sdk import (
     CreateClusterVariableRequestValue,
     CreateGlobalTaskListenerRequest,
     ExpressionEvaluationRequest,
+    FormKey,
     GlobalListenerId,
     GlobalTaskListenerEventTypeEnum,
     GlobalTaskListenerSearchQueryRequest,
@@ -537,3 +538,23 @@ def get_global_job_statistics_example() -> None:
 
     print(f"Global job stats: {result}")
 # endregion GetGlobalJobStatistics
+
+
+# region GetFormByKey
+def get_form_by_key_example(form_key: FormKey) -> None:
+    client = CamundaClient()
+
+    result = client.get_form_by_key(form_key=form_key)
+
+    print(f"Form: {result.form_id}")
+# endregion GetFormByKey
+
+
+# region GetResourceContentBinary
+def get_resource_content_binary_example() -> None:
+    client = CamundaClient()
+
+    content = client.get_resource_content_binary(resource_key="123456")
+
+    print(f"Binary content size: {len(content.payload.read())}")
+# endregion GetResourceContentBinary

--- a/examples/agent_instance.py
+++ b/examples/agent_instance.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from camunda_orchestration_sdk import (
+    AgentInstanceCreationRequest,
+    AgentInstanceCreationRequestDefinition,
     AgentInstanceKey,
     AgentInstanceSearchQuery,
+    AgentInstanceUpdateRequest,
+    AgentInstanceUpdateRequestStatus,
     CamundaClient,
+    ElementInstanceKey,
     Unset,
 )
 
@@ -32,3 +37,35 @@ def search_agent_instances_example() -> None:
         for agent_instance in result.items:
             print(f"Agent instance key: {agent_instance.agent_instance_key}")
 # endregion SearchAgentInstances
+
+
+# region CreateAgentInstance
+def create_agent_instance_example(element_instance_key: ElementInstanceKey) -> None:
+    client = CamundaClient()
+
+    result = client.create_agent_instance(
+        data=AgentInstanceCreationRequest(
+            element_instance_key=element_instance_key,
+            definition=AgentInstanceCreationRequestDefinition(
+                model="gpt-4o",
+                provider="openai",
+                system_prompt="You are a helpful assistant.",
+            ),
+        ),
+    )
+
+    print(f"Created agent instance: {result.agent_instance_key}")
+# endregion CreateAgentInstance
+
+
+# region UpdateAgentInstance
+def update_agent_instance_example(agent_instance_key: AgentInstanceKey) -> None:
+    client = CamundaClient()
+
+    client.update_agent_instance(
+        agent_instance_key=agent_instance_key,
+        data=AgentInstanceUpdateRequest(
+            status=AgentInstanceUpdateRequestStatus.THINKING,
+        ),
+    )
+# endregion UpdateAgentInstance

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -13,6 +13,20 @@
             "label": "Search agent instances"
         }
     ],
+    "create_agent_instance": [
+        {
+            "file": "agent_instance.py",
+            "region": "CreateAgentInstance",
+            "label": "Create an agent instance"
+        }
+    ],
+    "update_agent_instance": [
+        {
+            "file": "agent_instance.py",
+            "region": "UpdateAgentInstance",
+            "label": "Update an agent instance"
+        }
+    ],
     "get_topology": [
         {
             "file": "admin_operations.py",
@@ -888,6 +902,13 @@
             "label": "Get start process form"
         }
     ],
+    "get_form_by_key": [
+        {
+            "file": "admin_operations.py",
+            "region": "GetFormByKey",
+            "label": "Get a form by key"
+        }
+    ],
     "get_variable": [
         {
             "file": "extended_operations.py",
@@ -1229,6 +1250,13 @@
             "file": "admin_operations.py",
             "region": "GetResourceContent",
             "label": "Get resource content"
+        }
+    ],
+    "get_resource_content_binary": [
+        {
+            "file": "admin_operations.py",
+            "region": "GetResourceContentBinary",
+            "label": "Get resource content as binary"
         }
     ],
     "search_resources": [

--- a/hooks/post_gen/0100_generate_typed_exceptions.py
+++ b/hooks/post_gen/0100_generate_typed_exceptions.py
@@ -9,6 +9,7 @@ _STATUS_CLASSES: dict[int, tuple[str, str]] = {
     403: ("ForbiddenError", "The request is not allowed."),
     404: ("NotFoundError", "The requested resource was not found."),
     405: ("MethodNotAllowedError", "The HTTP method is not allowed for this resource."),
+    406: ("NotAcceptableError", "The requested content type is not acceptable."),
     408: ("RequestTimeoutError", "The request timed out."),
     409: (
         "ConflictError",

--- a/hooks/post_gen/0200_raise_exceptions.py
+++ b/hooks/post_gen/0200_raise_exceptions.py
@@ -18,6 +18,7 @@ def _status_class_name(code: int) -> str:
         403: "ForbiddenError",
         404: "NotFoundError",
         405: "MethodNotAllowedError",
+        406: "NotAcceptableError",
         408: "RequestTimeoutError",
         409: "ConflictError",
         410: "GoneError",


### PR DESCRIPTION
Add type-checked examples and operation-map entries for the 4 new operations introduced in the latest upstream spec:

- `createAgentInstance` (POST /agent-instances)
- `updateAgentInstance` (PATCH /agent-instances/{agentInstanceKey})
- `getFormByKey` (GET /forms/{formKey})
- `getResourceContentBinary` (GET /resources/{resourceKey}/content/binary)

Brings example coverage to 190/190 (100%).

**Files changed:**
- `examples/agent_instance.py` — added `CreateAgentInstance` and `UpdateAgentInstance` examples
- `examples/admin_operations.py` — added `GetFormByKey` and `GetResourceContentBinary` examples
- `examples/operation-map.json` — added 4 new entries
- `hooks/post_gen/0100_generate_typed_exceptions.py` — added 406 `NotAcceptableError` (returned by `getDocumentContent` when the requested content type is not available)
- `hooks/post_gen/0200_raise_exceptions.py` — added 406 → `NotAcceptableError` mapping

All examples are type-checked via `pyright`.