### PR TITLE
ci: add breaking change guard to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: camunda/sdk-infra/.github/workflows/sdk-commitlint.yml@v1
 
+  breaking-change-guard:
+    if: github.event_name == 'pull_request'
+    uses: camunda/sdk-infra/.github/workflows/sdk-breaking-change-guard.yml@v1
+
   spec-ref-guard:
     uses: camunda/sdk-infra/.github/workflows/sdk-spec-ref-guard.yml@v1
     with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,12 @@ chore: address review comments — clarify dry-run output
 fix: address review comments — clarify dry-run output
 ```
 
+### Breaking change commits
+
+Breaking change markers (`BREAKING CHANGE:` in the body/footer) trigger a major version bump and a CHANGELOG entry. **Never** use these markers for intra-branch corrections on a feature branch — they pollute the release history and cause unnecessary major version increments.
+
+PR CI includes a breaking change guard that fails when it detects these markers. If the breaking change is intentional, add the `breaking-change-approved` label to the PR. Otherwise, rewrite the commit history to remove the markers before merging.
+
 ### Separate generator changes from regenerated output
 
 When a change modifies the generator (hooks under `hooks/`, `generate.py`, generator config, `runtime/` files that get copied verbatim, build scripts) **and** that change causes `generated/*` (and/or `stubs/*`) to differ, **split the work into two commits**:


### PR DESCRIPTION
Adds the shared `sdk-breaking-change-guard` reusable workflow from `sdk-infra` to PR CI. This fails the build when PR commits contain `BREAKING CHANGE:` notes that would trigger an unintended major version bump via semantic-release.

## Changes

- **`.github/workflows/ci.yml`**: Added `breaking-change-guard` job (runs on PRs only)
- **`AGENTS.md`**: Documented breaking change commit conventions and the bypass label

## Bypass

Add the `breaking-change-approved` label to skip the guard for intentional breaking changes.

Closes #140