### PR TITLE
feat: default CAMUNDA_TENANT_ID(S) into request bodies with optional tenantIds[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,7 @@ All `CAMUNDA_*` environment variables recognised by the SDK. These can also be p
 | `CAMUNDA_TOKEN_DISK_CACHE_DISABLE` | `false` | Disable OAuth token disk caching. |
 | `CAMUNDA_SDK_BACKPRESSURE_PROFILE` | `BALANCED` | Backpressure profile: BALANCED (adaptive gating, default) or LEGACY (observe-only, no gating). |
 | `CAMUNDA_TENANT_ID` | — | Default tenant ID applied to all operations that accept a tenant_id parameter. |
+| `CAMUNDA_TENANT_IDS` | — | Default tenant IDs applied to operations whose request body accepts a plural ``tenantIds`` array (currently job activation). Accepts a comma-separated list when supplied via environment variable. Falls back to ``[CAMUNDA_TENANT_ID]`` when only the singular form is set. |
 | `CAMUNDA_WORKER_TIMEOUT` | — | Default job timeout in milliseconds for all workers. |
 | `CAMUNDA_WORKER_MAX_CONCURRENT_JOBS` | — | Default maximum concurrent jobs per worker. |
 | `CAMUNDA_WORKER_REQUEST_TIMEOUT` | — | Default long-poll request timeout in milliseconds for all workers. |

--- a/generated/camunda_orchestration_sdk/client.py
+++ b/generated/camunda_orchestration_sdk/client.py
@@ -6749,6 +6749,22 @@ class CamundaClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_IDS:
+            if hasattr(_body, "tenant_ids"):
+                _existing = _body.tenant_ids
+                if (
+                    _existing is None
+                    or _existing is UNSET
+                    or (isinstance(_existing, list) and not _existing)
+                ):
+                    _body.tenant_ids = list(self.configuration.CAMUNDA_TENANT_IDS)
+            elif isinstance(_body, dict):
+                _existing_d = _body.get("tenantIds")
+                if _existing_d is None or (
+                    isinstance(_existing_d, list) and not _existing_d
+                ):
+                    _body["tenantIds"] = list(self.configuration.CAMUNDA_TENANT_IDS)
         self._bp.acquire()
         try:
             _result = activate_jobs_sync(**_kwargs)
@@ -20827,6 +20843,22 @@ class CamundaAsyncClient:
         _kwargs["client"] = self.client
         if "data" in _kwargs:
             _kwargs["body"] = _kwargs.pop("data")
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_IDS:
+            if hasattr(_body, "tenant_ids"):
+                _existing = _body.tenant_ids
+                if (
+                    _existing is None
+                    or _existing is UNSET
+                    or (isinstance(_existing, list) and not _existing)
+                ):
+                    _body.tenant_ids = list(self.configuration.CAMUNDA_TENANT_IDS)
+            elif isinstance(_body, dict):
+                _existing_d = _body.get("tenantIds")
+                if _existing_d is None or (
+                    isinstance(_existing_d, list) and not _existing_d
+                ):
+                    _body["tenantIds"] = list(self.configuration.CAMUNDA_TENANT_IDS)
         await self._bp.acquire()
         try:
             _result = await activate_jobs_asyncio(**_kwargs)

--- a/generated/camunda_orchestration_sdk/runtime/configuration_resolver.py
+++ b/generated/camunda_orchestration_sdk/runtime/configuration_resolver.py
@@ -4,7 +4,14 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping, TypedDict, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 
 CamundaAuthStrategy = Literal["NONE", "OAUTH", "BASIC"]
@@ -50,6 +57,7 @@ class CamundaSdkConfigPartial(TypedDict, total=False):
 
     # Tenant
     CAMUNDA_TENANT_ID: str
+    CAMUNDA_TENANT_IDS: str | list[str]
 
     # Worker defaults
     CAMUNDA_WORKER_TIMEOUT: str
@@ -91,6 +99,7 @@ CAMUNDA_SDK_CONFIG_KEYS: tuple[str, ...] = (
     "CAMUNDA_SDK_BACKPRESSURE_PROFILE",
     # Tenant
     "CAMUNDA_TENANT_ID",
+    "CAMUNDA_TENANT_IDS",
     # Worker defaults
     "CAMUNDA_WORKER_TIMEOUT",
     "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
@@ -254,6 +263,33 @@ class CamundaSdkConfiguration(BaseModel):
         default=None,
         description="Default tenant ID applied to all operations that accept a tenant_id parameter.",
     )
+    CAMUNDA_TENANT_IDS: list[str] | None = Field(
+        default=None,
+        description=(
+            "Default tenant IDs applied to operations whose request body accepts a "
+            "plural ``tenantIds`` array (currently job activation). Accepts a "
+            "comma-separated list when supplied via environment variable. "
+            "Falls back to ``[CAMUNDA_TENANT_ID]`` when only the singular form is set."
+        ),
+    )
+
+    @field_validator("CAMUNDA_TENANT_IDS", mode="before")
+    @classmethod
+    def _parse_tenant_ids(cls, value: Any) -> Any:
+        # Env-derived values arrive as comma-separated strings; programmatic
+        # callers may supply a list directly. Empty / whitespace-only entries
+        # are dropped so trailing commas or spurious blanks don't produce
+        # phantom tenant filters in outgoing requests.
+        if value is None:
+            return None
+        if isinstance(value, str):
+            parts = [p.strip() for p in value.split(",")]
+            cleaned = [p for p in parts if p]
+            return cleaned or None
+        if isinstance(value, (list, tuple)):
+            cleaned = [str(p).strip() for p in value if str(p).strip()]
+            return cleaned or None
+        return value
 
     # Worker defaults
     CAMUNDA_WORKER_TIMEOUT: int | None = Field(
@@ -330,6 +366,13 @@ class CamundaSdkConfiguration(BaseModel):
         self.CAMUNDA_REST_ADDRESS = self._normalize_rest_address(  # pyright: ignore[reportConstantRedefinition]
             self.CAMUNDA_REST_ADDRESS
         )
+
+        # Tenant defaults: when only the singular CAMUNDA_TENANT_ID is set,
+        # mirror it into the plural CAMUNDA_TENANT_IDS so generated code that
+        # defaults plural ``tenantIds`` arrays gets the same effective tenant
+        # filter without forcing users to set both.
+        if self.CAMUNDA_TENANT_IDS is None and self.CAMUNDA_TENANT_ID is not None:
+            self.CAMUNDA_TENANT_IDS = [self.CAMUNDA_TENANT_ID]  # pyright: ignore[reportConstantRedefinition]
 
         if self.CAMUNDA_AUTH_STRATEGY == "BASIC":
             if not self.CAMUNDA_BASIC_AUTH_USERNAME:

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -425,6 +425,25 @@ _BODY_TENANT_INJECTION = """
                 _body["tenantId"] = self.configuration.CAMUNDA_TENANT_ID"""
 
 
+# Template for body tenantIds[] injection code. Mirrors the singular tenant_id
+# logic but for operations whose request body exposes an optional plural
+# ``tenantIds`` array (currently job activation). The plural env var
+# ``CAMUNDA_TENANT_IDS`` is resolved server-side to ``[CAMUNDA_TENANT_ID]``
+# when only the singular form is set, so workers configured with a single
+# tenant ID still get tenant-scoped polling without extra config.
+_BODY_TENANT_IDS_INJECTION = """
+        _body = _kwargs.get("body")
+        if _body is not None and self.configuration.CAMUNDA_TENANT_IDS:
+            if hasattr(_body, "tenant_ids"):
+                _existing = _body.tenant_ids
+                if _existing is None or _existing is UNSET or (isinstance(_existing, list) and not _existing):
+                    _body.tenant_ids = list(self.configuration.CAMUNDA_TENANT_IDS)
+            elif isinstance(_body, dict):
+                _existing_d = _body.get("tenantIds")
+                if _existing_d is None or (isinstance(_existing_d, list) and not _existing_d):
+                    _body["tenantIds"] = list(self.configuration.CAMUNDA_TENANT_IDS)"""
+
+
 def _compute_body_tenant_ops(spec_path: Path | None) -> set[str]:
     """Return snake_case method names for operations with optional tenantId in request body.
 
@@ -486,6 +505,70 @@ def _compute_body_tenant_ops(spec_path: Path | None) -> set[str]:
     return ops
 
 
+def _compute_body_tenant_ids_ops(spec_path: Path | None) -> set[str]:
+    """Return snake_case method names for operations with optional ``tenantIds[]`` in request body.
+
+    Parallel to :func:`_compute_body_tenant_ops` but matches operations whose
+    request body exposes a plural ``tenantIds`` array (e.g. ``activate_jobs``).
+    The runtime contract for these is the same: when the caller omits
+    ``tenant_ids`` (or passes an empty list) and a default is configured via
+    ``CAMUNDA_TENANT_IDS`` / ``CAMUNDA_TENANT_ID``, inject the configured
+    tenant list so multi-tenant workers don't silently poll without a filter.
+    """
+    if spec_path is None or not spec_path.exists():
+        return set()
+
+    with open(spec_path, "r", encoding="utf-8") as f:
+        if spec_path.suffix == ".json":
+            spec: dict[str, Any] = json.load(f)
+        else:
+            import yaml
+            spec = yaml.safe_load(f)
+
+    def resolve_ref(ref: str) -> dict[str, Any]:
+        parts = ref.lstrip("#/").split("/")
+        node: Any = spec
+        for p in parts:
+            node = node[p]
+        return cast(dict[str, Any], node)
+
+    def has_optional_tenant_ids(schema: dict[str, Any], depth: int = 0) -> bool:
+        if depth > 5:
+            return False
+        if "$ref" in schema:
+            return has_optional_tenant_ids(resolve_ref(schema["$ref"]), depth + 1)
+        props: dict[str, Any] = schema.get("properties", {})
+        if "tenantIds" in props and "tenantIds" not in schema.get("required", []):
+            prop = props["tenantIds"]
+            if isinstance(prop, dict) and prop.get("type") == "array":
+                return True
+        variants: list[dict[str, Any]] = schema.get("oneOf", []) + schema.get("anyOf", [])
+        for variant in variants:
+            if has_optional_tenant_ids(variant, depth + 1):
+                return True
+        return False
+
+    ops: set[str] = set()
+    paths: dict[str, Any] = spec.get("paths", {})
+    for _path, methods in paths.items():
+        for method, op in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+            op_id: str = op.get("operationId", "")
+            body: dict[str, Any] = op.get("requestBody", {}).get("content", {})
+            for _ct, ct_data in body.items():
+                schema: dict[str, Any] = ct_data.get("schema", {})
+                if has_optional_tenant_ids(schema):
+                    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", op_id)
+                    snake = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+                    ops.add(snake)
+                    break
+
+    if ops:
+        print(f"[flatten-client] body-tenant-ids-injection ops ({len(ops)}): {sorted(ops)}")
+    return ops
+
+
 def _compute_eventual_ops(metadata_path: Path | None) -> dict[str, bool]:
     """Return a mapping of snake_case method name → is_get for eventually-consistent operations.
 
@@ -521,6 +604,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
         return
 
     body_tenant_ops = _compute_body_tenant_ops(spec_path)
+    body_tenant_ids_ops = _compute_body_tenant_ids_ops(spec_path)
     eventual_ops = _compute_eventual_ops(metadata_path)
 
     sync_methods: list[str] = []
@@ -643,7 +727,11 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                 # Body-tenant injection: for operations where tenantId is an optional
                 # field in the request body (tenant-as-context), inject the configured
                 # default tenant ID into the body model when the caller omits it.
-                tenant_id_injection = _BODY_TENANT_INJECTION if method_name in body_tenant_ops else ""
+                tenant_id_injection = ""
+                if method_name in body_tenant_ops:
+                    tenant_id_injection += _BODY_TENANT_INJECTION
+                if method_name in body_tenant_ids_ops:
+                    tenant_id_injection += _BODY_TENANT_IDS_INJECTION
 
                 # Eventual consistency: add optional keyword-only consistency parameter
                 is_eventual = method_name in eventual_ops
@@ -801,7 +889,11 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                 docstring_str = f'        """{safe_docstring(docstring)}"""\n' if docstring else ""
 
                 # Body-tenant injection: same logic as sync methods
-                tenant_id_injection = _BODY_TENANT_INJECTION if method_name in body_tenant_ops else ""
+                tenant_id_injection = ""
+                if method_name in body_tenant_ops:
+                    tenant_id_injection += _BODY_TENANT_INJECTION
+                if method_name in body_tenant_ids_ops:
+                    tenant_id_injection += _BODY_TENANT_IDS_INJECTION
 
                 # Eventual consistency: add optional keyword-only consistency parameter
                 is_eventual = method_name in eventual_ops

--- a/runtime/configuration_resolver.py
+++ b/runtime/configuration_resolver.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping, TypedDict, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 
 CamundaAuthStrategy = Literal["NONE", "OAUTH", "BASIC"]
@@ -50,6 +50,7 @@ class CamundaSdkConfigPartial(TypedDict, total=False):
 
     # Tenant
     CAMUNDA_TENANT_ID: str
+    CAMUNDA_TENANT_IDS: str | list[str]
 
     # Worker defaults
     CAMUNDA_WORKER_TIMEOUT: str
@@ -91,6 +92,7 @@ CAMUNDA_SDK_CONFIG_KEYS: tuple[str, ...] = (
     "CAMUNDA_SDK_BACKPRESSURE_PROFILE",
     # Tenant
     "CAMUNDA_TENANT_ID",
+    "CAMUNDA_TENANT_IDS",
     # Worker defaults
     "CAMUNDA_WORKER_TIMEOUT",
     "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
@@ -254,6 +256,33 @@ class CamundaSdkConfiguration(BaseModel):
         default=None,
         description="Default tenant ID applied to all operations that accept a tenant_id parameter.",
     )
+    CAMUNDA_TENANT_IDS: list[str] | None = Field(
+        default=None,
+        description=(
+            "Default tenant IDs applied to operations whose request body accepts a "
+            "plural ``tenantIds`` array (currently job activation). Accepts a "
+            "comma-separated list when supplied via environment variable. "
+            "Falls back to ``[CAMUNDA_TENANT_ID]`` when only the singular form is set."
+        ),
+    )
+
+    @field_validator("CAMUNDA_TENANT_IDS", mode="before")
+    @classmethod
+    def _parse_tenant_ids(cls, value: Any) -> Any:
+        # Env-derived values arrive as comma-separated strings; programmatic
+        # callers may supply a list directly. Empty / whitespace-only entries
+        # are dropped so trailing commas or spurious blanks don't produce
+        # phantom tenant filters in outgoing requests.
+        if value is None:
+            return None
+        if isinstance(value, str):
+            parts = [p.strip() for p in value.split(",")]
+            cleaned = [p for p in parts if p]
+            return cleaned or None
+        if isinstance(value, (list, tuple)):
+            cleaned = [str(p).strip() for p in value if str(p).strip()]
+            return cleaned or None
+        return value
 
     # Worker defaults
     CAMUNDA_WORKER_TIMEOUT: int | None = Field(
@@ -330,6 +359,13 @@ class CamundaSdkConfiguration(BaseModel):
         self.CAMUNDA_REST_ADDRESS = self._normalize_rest_address(  # pyright: ignore[reportConstantRedefinition]
             self.CAMUNDA_REST_ADDRESS
         )
+
+        # Tenant defaults: when only the singular CAMUNDA_TENANT_ID is set,
+        # mirror it into the plural CAMUNDA_TENANT_IDS so generated code that
+        # defaults plural ``tenantIds`` arrays gets the same effective tenant
+        # filter without forcing users to set both.
+        if self.CAMUNDA_TENANT_IDS is None and self.CAMUNDA_TENANT_ID is not None:
+            self.CAMUNDA_TENANT_IDS = [self.CAMUNDA_TENANT_ID]  # pyright: ignore[reportConstantRedefinition]
 
         if self.CAMUNDA_AUTH_STRATEGY == "BASIC":
             if not self.CAMUNDA_BASIC_AUTH_USERNAME:

--- a/stubs/camunda_orchestration_sdk/runtime/configuration_resolver.pyi
+++ b/stubs/camunda_orchestration_sdk/runtime/configuration_resolver.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Mapping, TypedDict, Literal
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 CamundaAuthStrategy = Literal["NONE", "OAUTH", "BASIC"]
 CamundaSdkLogLevel = Literal[
@@ -33,6 +33,7 @@ class CamundaSdkConfigPartial(TypedDict):
     CAMUNDA_TOKEN_DISK_CACHE_DISABLE: str
     CAMUNDA_SDK_BACKPRESSURE_PROFILE: str
     CAMUNDA_TENANT_ID: str
+    CAMUNDA_TENANT_IDS: str | list[str]
     CAMUNDA_WORKER_TIMEOUT: str
     CAMUNDA_WORKER_MAX_CONCURRENT_JOBS: str
     CAMUNDA_WORKER_REQUEST_TIMEOUT: str
@@ -67,6 +68,7 @@ CAMUNDA_SDK_CONFIG_KEYS: tuple[str, ...] = (
     "CAMUNDA_SDK_BACKPRESSURE_PROFILE",
     # Tenant
     "CAMUNDA_TENANT_ID",
+    "CAMUNDA_TENANT_IDS",
     # Worker defaults
     "CAMUNDA_WORKER_TIMEOUT",
     "CAMUNDA_WORKER_MAX_CONCURRENT_JOBS",
@@ -154,6 +156,18 @@ class CamundaSdkConfiguration(BaseModel):
         default=None,
         description="Default tenant ID applied to all operations that accept a tenant_id parameter.",
     )
+    CAMUNDA_TENANT_IDS: list[str] | None = Field(
+        default=None,
+        description=(
+            "Default tenant IDs applied to operations whose request body accepts a "
+            "plural ``tenantIds`` array (currently job activation). Accepts a "
+            "comma-separated list when supplied via environment variable. "
+            "Falls back to ``[CAMUNDA_TENANT_ID]`` when only the singular form is set."
+        ),
+    )
+    @field_validator("CAMUNDA_TENANT_IDS", mode="before")
+    @classmethod
+    def _parse_tenant_ids(cls, value: Any) -> Any: ...
     CAMUNDA_WORKER_TIMEOUT: int | None = Field(
         default=None,
         description="Default job timeout in milliseconds for all workers.",

--- a/tests/acceptance/test_configuration_resolver.py
+++ b/tests/acceptance/test_configuration_resolver.py
@@ -19,6 +19,7 @@ def _clear_camunda_env(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ign
         "CAMUNDA_BASIC_AUTH_USERNAME",
         "CAMUNDA_BASIC_AUTH_PASSWORD",
         "CAMUNDA_TENANT_ID",
+        "CAMUNDA_TENANT_IDS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -272,3 +273,51 @@ def test_tenant_id_explicit_overrides_environment(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("CAMUNDA_TENANT_ID", "env-tenant")
     client = CamundaClient(configuration={"CAMUNDA_TENANT_ID": "explicit-tenant"})
     assert client.configuration.CAMUNDA_TENANT_ID == "explicit-tenant"
+
+
+def test_tenant_ids_defaults_to_none():
+    from camunda_orchestration_sdk import CamundaClient
+
+    client = CamundaClient()
+    assert client.configuration.CAMUNDA_TENANT_IDS is None
+
+
+def test_tenant_ids_falls_back_to_singular_tenant_id(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+
+    monkeypatch.setenv("CAMUNDA_TENANT_ID", "tenant-a")
+    client = CamundaClient()
+    assert client.configuration.CAMUNDA_TENANT_IDS == ["tenant-a"]
+
+
+def test_tenant_ids_from_environment_comma_separated(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "tenant-a,tenant-b, tenant-c ")
+    client = CamundaClient()
+    assert client.configuration.CAMUNDA_TENANT_IDS == ["tenant-a", "tenant-b", "tenant-c"]
+
+
+def test_tenant_ids_plural_does_not_get_overridden_by_singular(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+
+    monkeypatch.setenv("CAMUNDA_TENANT_ID", "singular")
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "a,b")
+    client = CamundaClient()
+    assert client.configuration.CAMUNDA_TENANT_IDS == ["a", "b"]
+
+
+def test_tenant_ids_from_explicit_list():
+    from camunda_orchestration_sdk import CamundaClient
+
+    client = CamundaClient(configuration={"CAMUNDA_TENANT_IDS": ["x", "y"]})
+    assert client.configuration.CAMUNDA_TENANT_IDS == ["x", "y"]
+
+
+def test_tenant_ids_empty_env_falls_back_to_singular(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+
+    monkeypatch.setenv("CAMUNDA_TENANT_ID", "only-singular")
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "   ,  ,")
+    client = CamundaClient()
+    assert client.configuration.CAMUNDA_TENANT_IDS == ["only-singular"]

--- a/tests/acceptance/test_default_tenant_ids.py
+++ b/tests/acceptance/test_default_tenant_ids.py
@@ -1,0 +1,208 @@
+"""Tests for default ``tenantIds[]`` injection.
+
+Mirrors the structural / class-of-defect coverage applied by the JS SDK
+(`camunda/orchestration-cluster-api-js#171`): every operation whose request
+body exposes an *optional* plural ``tenantIds`` array must have the default
+tenant injection block emitted by the post-gen flatten-client hook, so
+multi-tenant workers don't silently poll without a tenant filter when
+``CAMUNDA_TENANT_ID`` / ``CAMUNDA_TENANT_IDS`` is configured.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUNDLED_SPEC = REPO_ROOT / "generated" / "bundled_spec.yaml"
+GENERATED_CLIENT = REPO_ROOT / "generated" / "camunda_orchestration_sdk" / "client.py"
+
+
+@pytest.fixture(autouse=True)
+def _clear_camunda_env(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    for key in ("CAMUNDA_TENANT_ID", "CAMUNDA_TENANT_IDS"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _snake(op_id: str) -> str:
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", op_id)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _resolve_ref(spec: dict[str, Any], ref: str) -> dict[str, Any]:
+    node: Any = spec
+    for part in ref.lstrip("#/").split("/"):
+        node = node[part]
+    return node
+
+
+def _schema_has_optional_tenant_ids(spec: dict[str, Any], schema: dict[str, Any], depth: int = 0) -> bool:
+    if depth > 5 or not isinstance(schema, dict):
+        return False
+    if "$ref" in schema:
+        return _schema_has_optional_tenant_ids(spec, _resolve_ref(spec, schema["$ref"]), depth + 1)
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    if "tenantIds" in props and "tenantIds" not in required:
+        prop = props["tenantIds"]
+        if isinstance(prop, dict) and prop.get("type") == "array":
+            return True
+    for variant in schema.get("oneOf", []) + schema.get("anyOf", []):
+        if _schema_has_optional_tenant_ids(spec, variant, depth + 1):
+            return True
+    return False
+
+
+def _ops_with_optional_tenant_ids_body() -> list[str]:
+    with open(BUNDLED_SPEC, "r", encoding="utf-8") as f:
+        spec = yaml.safe_load(f)
+    found: set[str] = set()
+    for _path, methods in spec.get("paths", {}).items():
+        for verb, op in methods.items():
+            if verb not in ("get", "post", "put", "patch", "delete"):
+                continue
+            body = op.get("requestBody", {}).get("content", {}) or {}
+            for _ct, data in body.items():
+                schema = data.get("schema", {})
+                if _schema_has_optional_tenant_ids(spec, schema):
+                    found.add(_snake(op.get("operationId", "")))
+                    break
+    return sorted(found)
+
+
+def test_spec_has_at_least_one_op_with_optional_tenant_ids():
+    """Guard: if upstream removes every op with optional tenantIds[],
+    the structural test below would vacuously pass — fail loudly instead."""
+    assert _ops_with_optional_tenant_ids_body(), (
+        "Expected at least one operation with optional tenantIds[] in body. "
+        "If the upstream spec genuinely removed every such operation, delete "
+        "this guard and the injection logic; otherwise the spec scanner is broken."
+    )
+
+
+def test_every_optional_tenant_ids_op_has_injection_block():
+    """Class-of-defect guard: every operation with optional tenantIds[] must
+    have the default-tenant-ids injection block in both sync and async impls."""
+    client_src = GENERATED_CLIENT.read_text(encoding="utf-8")
+    missing: list[str] = []
+    for method in _ops_with_optional_tenant_ids_body():
+        # Match the def + signature + (closely following) the injection block.
+        # We assert each method's body contains the CAMUNDA_TENANT_IDS sentinel,
+        # and that the sentinel appears at least twice in the file (sync + async).
+        sync_pat = re.compile(
+            rf"    def {re.escape(method)}\(.*?(?=\n    (?:def|async def) |\Z)",
+            re.DOTALL,
+        )
+        async_pat = re.compile(
+            rf"    async def {re.escape(method)}\(.*?(?=\n    (?:def|async def) |\Z)",
+            re.DOTALL,
+        )
+        for kind, pat in (("sync", sync_pat), ("async", async_pat)):
+            match = pat.search(client_src)
+            if not match or "self.configuration.CAMUNDA_TENANT_IDS" not in match.group(0):
+                missing.append(f"{kind}:{method}")
+    assert not missing, (
+        f"Missing default-tenant-ids injection block in: {missing}. "
+        "The post-gen flatten-client hook (hooks/post_gen/0900_flatten_client.py) "
+        "must inject _BODY_TENANT_IDS_INJECTION for every op with optional tenantIds[]."
+    )
+
+
+# --- Behavioral tests for activate_jobs ---------------------------------------
+
+
+def _capture_handler(captured: dict[str, Any]):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.content:
+            try:
+                captured["body"] = json.loads(request.content)
+            except json.JSONDecodeError:
+                captured["body"] = None
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={"jobs": []},
+            headers={"content-type": "application/json"},
+        )
+
+    return handler
+
+
+def test_activate_jobs_injects_default_tenant_ids_from_singular_env(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+    from camunda_orchestration_sdk.models.job_activation_request import JobActivationRequest
+
+    monkeypatch.setenv("CAMUNDA_TENANT_ID", "tenant-a")
+    captured: dict[str, Any] = {}
+    client = CamundaClient(httpx_args={"transport": httpx.MockTransport(_capture_handler(captured))})
+
+    client.activate_jobs(data=JobActivationRequest(type_="payment", timeout=30000, max_jobs_to_activate=5))
+
+    assert captured.get("body", {}).get("tenantIds") == ["tenant-a"]
+
+
+def test_activate_jobs_injects_default_tenant_ids_from_plural_env(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+    from camunda_orchestration_sdk.models.job_activation_request import JobActivationRequest
+
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "tenant-a,tenant-b")
+    captured: dict[str, Any] = {}
+    client = CamundaClient(httpx_args={"transport": httpx.MockTransport(_capture_handler(captured))})
+
+    client.activate_jobs(data=JobActivationRequest(type_="payment", timeout=30000, max_jobs_to_activate=5))
+
+    assert captured.get("body", {}).get("tenantIds") == ["tenant-a", "tenant-b"]
+
+
+def test_activate_jobs_preserves_explicit_tenant_ids(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaClient
+    from camunda_orchestration_sdk.models.job_activation_request import JobActivationRequest
+
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "default-a,default-b")
+    captured: dict[str, Any] = {}
+    client = CamundaClient(httpx_args={"transport": httpx.MockTransport(_capture_handler(captured))})
+
+    client.activate_jobs(
+        data=JobActivationRequest(
+            type_="payment",
+            timeout=30000,
+            max_jobs_to_activate=5,
+            tenant_ids=["explicit-x"],
+        )
+    )
+
+    assert captured.get("body", {}).get("tenantIds") == ["explicit-x"]
+
+
+def test_activate_jobs_no_default_no_injection():
+    from camunda_orchestration_sdk import CamundaClient
+    from camunda_orchestration_sdk.models.job_activation_request import JobActivationRequest
+
+    captured: dict[str, Any] = {}
+    client = CamundaClient(httpx_args={"transport": httpx.MockTransport(_capture_handler(captured))})
+
+    client.activate_jobs(data=JobActivationRequest(type_="payment", timeout=30000, max_jobs_to_activate=5))
+
+    # No tenant configured anywhere → tenantIds key must NOT be added.
+    assert "tenantIds" not in (captured.get("body") or {})
+
+
+@pytest.mark.asyncio
+async def test_activate_jobs_async_injects_default_tenant_ids(monkeypatch: pytest.MonkeyPatch):
+    from camunda_orchestration_sdk import CamundaAsyncClient
+    from camunda_orchestration_sdk.models.job_activation_request import JobActivationRequest
+
+    monkeypatch.setenv("CAMUNDA_TENANT_IDS", "async-a,async-b")
+    captured: dict[str, Any] = {}
+    client = CamundaAsyncClient(httpx_args={"transport": httpx.MockTransport(_capture_handler(captured))})
+
+    await client.activate_jobs(data=JobActivationRequest(type_="payment", timeout=30000, max_jobs_to_activate=5))
+
+    assert captured.get("body", {}).get("tenantIds") == ["async-a", "async-b"]

--- a/uv.lock
+++ b/uv.lock
@@ -102,7 +102,7 @@ wheels = [
 
 [[package]]
 name = "camunda-orchestration-sdk"
-version = "10.1.0.dev8"
+version = "10.1.0.dev9"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Closes #120.

## Summary

Python counterpart of [orchestration-cluster-api-js#170](https://github.com/camunda/orchestration-cluster-api-js/issues/170) / [JS PR #171](https://github.com/camunda/orchestration-cluster-api-js/pull/171).

Previously, `JobWorker._poll_for_jobs` constructed `JobActivationRequest` without `tenant_ids`, so a worker configured with `CAMUNDA_TENANT_ID` would silently poll across all tenants instead of just the configured one.

Following the JS SDK approach, this is fixed at the **generator layer** rather than per-call in JobWorker, so every operation whose request body exposes an optional plural `tenantIds[]` array gets the configured default tenant list — not just `activate_jobs`.

## Changes

- **`runtime/configuration_resolver.py`** — adds `CAMUNDA_TENANT_IDS` (`list[str]`):
  - Parses comma-separated env values (e.g. `CAMUNDA_TENANT_IDS=a,b,c`).
  - Falls back to `[CAMUNDA_TENANT_ID]` when only the singular form is set, so existing single-tenant deployments keep working without config churn.
- **`hooks/post_gen/0900_flatten_client.py`** — scans the bundled spec for ops with optional `tenantIds[]` in the request body and emits a parallel injection block (`_BODY_TENANT_IDS_INJECTION`) alongside the existing singular `tenantId` injection. Handles both attrs models (`tenant_ids`) and dict bodies (`tenantIds`); never overwrites an explicit non-empty value supplied by the caller.
- **Tests** — class-of-defect structural guard (spec scan → assert injection present in every matching op's generated impl) plus behavioural coverage:
  - default from singular `CAMUNDA_TENANT_ID`
  - default from plural `CAMUNDA_TENANT_IDS`
  - explicit `tenant_ids=[...]` preserved
  - no default → no injection (request body unchanged)
  - async path
- **Docs** — `README.md` config reference regenerated to include `CAMUNDA_TENANT_IDS`.

## Commit structure

Per `AGENTS.md`, split into two commits:

1. `feat(runtime): default CAMUNDA_TENANT_ID(S) into request bodies with optional tenantIds[]` — source (resolver, hook, tests, docs).
2. `chore(generation): regenerate SDK for default-tenant-ids injection` — regenerated `generated/*` + `stubs/*`.

## Pre-push checklist

- [x] `make generate` — clean.
- [x] `make lint` — clean.
- [x] `make typecheck` (`ty`) — clean.
- [x] `make test` — 471 passed.

## Related

- Issue #120
- JS counterpart: camunda/orchestration-cluster-api-js#170 / #171
