### PR TITLE
feat: improve job worker autocomplete, variables, and logging

### DIFF
--- a/generated/camunda_orchestration_sdk/runtime/job_worker.py
+++ b/generated/camunda_orchestration_sdk/runtime/job_worker.py
@@ -42,8 +42,8 @@ EXECUTION_STRATEGY = _EFFECTIVE_EXECUTION_STRATEGY | Literal["auto"]
 ActionComplete = Tuple[
     Literal["complete"], Union[dict[str, Any], JobCompletionRequest, None]
 ]
-ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int]]
-ActionError = Tuple[Literal["error"], Tuple[str, str]]
+ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int, dict[str, Any] | None]]
+ActionError = Tuple[Literal["error"], Tuple[str, str, dict[str, Any] | None]]
 ActionSubprocessError = Tuple[Literal["subprocess_error"], str]
 
 JobAction = Union[ActionComplete, ActionFail, ActionError, ActionSubprocessError]
@@ -89,13 +89,13 @@ class ConnectedJobContext(JobContext):
     For ``"process"`` handlers, see :class:`JobContext`.
     """
 
-    client: "CamundaAsyncClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaAsyncClient = attrs.field(kw_only=True, repr=False, eq=False)
 
     @classmethod
     def create(
         cls,
         job: ActivatedJobResult,
-        client: "CamundaAsyncClient",
+        client: Any,
         logger: SdkLogger | None = None,
     ) -> "ConnectedJobContext":
         init_fields = {
@@ -126,13 +126,13 @@ class SyncJobContext(JobContext):
     For ``"process"`` handlers, see :class:`JobContext`.
     """
 
-    client: "CamundaClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaClient = attrs.field(kw_only=True, repr=False, eq=False)
 
     @classmethod
     def create(
         cls,
         job: ActivatedJobResult,
-        client: "CamundaClient",
+        client: Any,
         logger: SdkLogger | None = None,
     ) -> "SyncJobContext":
         init_fields = {
@@ -269,9 +269,15 @@ class _ResolvedWorkerConfig:
 class JobError(Exception):
     """Raise this exception to throw a BPMN error."""
 
-    def __init__(self, error_code: str, message: str = ""):
+    def __init__(
+        self,
+        error_code: str,
+        message: str = "",
+        variables: dict[str, Any] | None = None,
+    ):
         self.error_code = error_code
         self.message = message
+        self.variables = variables
         super().__init__(f"JobError[{error_code}]: {message}")
 
 
@@ -279,12 +285,108 @@ class JobFailure(Exception):
     """Raise this exception to explicitly fail a job with custom retries/backoff."""
 
     def __init__(
-        self, message: str, retries: int | None = None, retry_back_off: int = 0
+        self,
+        message: str,
+        retries: int | None = None,
+        retry_back_off: int = 0,
+        variables: dict[str, Any] | None = None,
     ):
         self.message = message
         self.retries = retries
         self.retry_back_off = retry_back_off
+        self.variables = variables
         super().__init__(f"JobFailure: {message}")
+
+
+class _AckFlag:
+    """Mutable flag shared between a job-scoped client wrapper and the worker dispatch."""
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = False
+
+
+class _JobScopedAsyncClient:
+    """Wraps ``CamundaAsyncClient`` to detect when a job has been explicitly
+    completed, failed, or errored by the handler \u2014 suppressing the worker's
+    automatic completion for that job."""
+
+    def __init__(
+        self,
+        client: "CamundaAsyncClient",
+        job_key: str,
+        ack: _AckFlag,
+    ) -> None:
+        object.__setattr__(self, "_inner", client)
+        object.__setattr__(self, "_job_key", job_key)
+        object.__setattr__(self, "_ack", ack)
+        object.__setattr__(self, "__wrapped__", client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+    async def complete_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").complete_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    async def fail_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").fail_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    async def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").throw_job_error(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+
+class _JobScopedSyncClient:
+    """Sync equivalent of :class:`_JobScopedAsyncClient` for thread-strategy handlers."""
+
+    def __init__(
+        self,
+        client: "CamundaClient",
+        job_key: str,
+        ack: _AckFlag,
+    ) -> None:
+        object.__setattr__(self, "_inner", client)
+        object.__setattr__(self, "_job_key", job_key)
+        object.__setattr__(self, "_ack", ack)
+        object.__setattr__(self, "__wrapped__", client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+    def complete_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").complete_job(job_key, **kwargs)
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    def fail_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").fail_job(job_key, **kwargs)
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").throw_job_error(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
 
 
 def _execute_task_isolated(
@@ -315,12 +417,12 @@ def _execute_task_isolated(
         return ("complete", result)
 
     except JobError as e:
-        return ("error", (e.error_code, e.message))
+        return ("error", (e.error_code, e.message, e.variables))
     except JobFailure as e:
-        return ("fail", (e.message, e.retries, e.retry_back_off))
+        return ("fail", (e.message, e.retries, e.retry_back_off, e.variables))
     except Exception as e:
         # Catch-all for other exceptions -> Fail job
-        return ("fail", (str(e), None, 0))
+        return ("fail", (str(e), None, 0, None))
 
 
 class JobWorker:
@@ -690,11 +792,15 @@ class JobWorker:
             self.running = True
             if self._startup_jitter_max_seconds > 0:
                 jitter = random.uniform(0, self._startup_jitter_max_seconds)
-                self.logger.info(f"Delaying worker start by {jitter:.2f}s (jitter)")
+                self.logger.info(
+                    f"Worker '{self.config.worker_name}' delaying start by {jitter:.2f}s (jitter)"
+                )
                 self.polling_task = asyncio.create_task(self._start_with_jitter(jitter))
             else:
                 self.polling_task = asyncio.create_task(self.poll_loop())
-            self.logger.info("Worker started")
+            self.logger.info(
+                f"Worker '{self.config.worker_name}' started for type '{self.config.job_type}'"
+            )
 
     async def _start_with_jitter(self, jitter: float):
         await asyncio.sleep(jitter)
@@ -719,7 +825,7 @@ class JobWorker:
             # allocated.
             self.close()
 
-            self.logger.info("Worker stopped")
+            self.logger.info(f"Worker '{self.config.worker_name}' stopped")
 
     async def aclose(self) -> None:
         """Async-aware teardown.
@@ -836,13 +942,20 @@ class JobWorker:
         # Create context with a job-scoped child logger
         job_logger = self.logger.bind(job_key=str(job_item.job_key))
         job_context: JobContext
+        ack_flag = _AckFlag()
         if self._strategy == "async":
+            wrapped_client = _JobScopedAsyncClient(
+                self.client, job_item.job_key, ack_flag
+            )
             job_context = ConnectedJobContext.create(
-                job_item, client=self.client, logger=job_logger
+                job_item, client=wrapped_client, logger=job_logger
             )
         elif self._strategy == "thread":
+            wrapped_sync = _JobScopedSyncClient(
+                self._get_sync_client(), job_item.job_key, ack_flag
+            )
             job_context = SyncJobContext.create(
-                job_item, client=self._get_sync_client(), logger=job_logger
+                job_item, client=wrapped_sync, logger=job_logger
             )
         else:
             job_context = JobContext.from_job(job_item, logger=job_logger)
@@ -871,11 +984,14 @@ class JobWorker:
                             result = sync_callback(job_context)
                         action = ("complete", result)
                     except JobError as e:
-                        action = ("error", (e.error_code, e.message))
+                        action = ("error", (e.error_code, e.message, e.variables))
                     except JobFailure as e:
-                        action = ("fail", (e.message, e.retries, e.retry_back_off))
+                        action = (
+                            "fail",
+                            (e.message, e.retries, e.retry_back_off, e.variables),
+                        )
                     except Exception as e:
-                        action = ("fail", (str(e), None, 0))
+                        action = ("fail", (str(e), None, 0, None))
 
                 elif self._strategy in ["thread", "process"]:
                     # Run in Pool (Isolated)
@@ -891,7 +1007,11 @@ class JobWorker:
 
                 # Handle the returned action
                 if action:
-                    if action[0] == "complete":
+                    if ack_flag.value:
+                        job_logger.debug(
+                            f"Job {job_context.job_key} already handled by handler; skipping auto-{action[0]}"
+                        )
+                    elif action[0] == "complete":
                         _, action_data = action
                         # Ensure data is in correct format
                         complete_data = JobCompletionRequest()
@@ -910,7 +1030,7 @@ class JobWorker:
                         self.logger.debug(f"Job completed: {job_context.job_key}")
 
                     elif action[0] == "fail":
-                        _, (error_message, retries, retry_back_off) = action
+                        _, (error_message, retries, retry_back_off, variables) = action
                         # Calculate retries if not provided
                         if retries is None:
                             retries = (
@@ -919,25 +1039,45 @@ class JobWorker:
                                 else 0
                             )
 
+                        fail_data = JobFailRequest(
+                            error_message=error_message,
+                            retries=retries,
+                            retry_back_off=retry_back_off,
+                        )
+                        if variables is not None:
+                            from camunda_orchestration_sdk.models.job_fail_request_variables import (
+                                JobFailRequestVariables,
+                            )
+
+                            fail_data.variables = JobFailRequestVariables.from_dict(
+                                variables
+                            )
+
                         await self.client.fail_job(
                             job_key=job_context.job_key,
-                            data=JobFailRequest(
-                                error_message=error_message,
-                                retries=retries,
-                                retry_back_off=retry_back_off,
-                            ),
+                            data=fail_data,
                         )
                         self.logger.info(
                             f"Job failed: {job_context.job_key} - {error_message}"
                         )
 
                     elif action[0] == "error":
-                        _, (error_code, error_message) = action
+                        _, (error_code, error_message, variables) = action
+                        error_data = JobErrorRequest(
+                            error_code=error_code, error_message=error_message
+                        )
+                        if variables is not None:
+                            from camunda_orchestration_sdk.models.job_error_request_variables import (
+                                JobErrorRequestVariables,
+                            )
+
+                            error_data.variables = JobErrorRequestVariables.from_dict(
+                                variables
+                            )
+
                         await self.client.throw_job_error(
                             job_key=job_context.job_key,
-                            data=JobErrorRequest(
-                                error_code=error_code, error_message=error_message
-                            ),
+                            data=error_data,
                         )
                         self.logger.info(
                             f"Job error thrown: {job_context.job_key} - {error_code}"

--- a/runtime/job_worker.py
+++ b/runtime/job_worker.py
@@ -42,8 +42,8 @@ EXECUTION_STRATEGY = _EFFECTIVE_EXECUTION_STRATEGY | Literal["auto"]
 ActionComplete = Tuple[
     Literal["complete"], Union[dict[str, Any], JobCompletionRequest, None]
 ]
-ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int]]
-ActionError = Tuple[Literal["error"], Tuple[str, str]]
+ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int, dict[str, Any] | None]]
+ActionError = Tuple[Literal["error"], Tuple[str, str, dict[str, Any] | None]]
 ActionSubprocessError = Tuple[Literal["subprocess_error"], str]
 
 JobAction = Union[ActionComplete, ActionFail, ActionError, ActionSubprocessError]
@@ -89,13 +89,13 @@ class ConnectedJobContext(JobContext):
     For ``"process"`` handlers, see :class:`JobContext`.
     """
 
-    client: "CamundaAsyncClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaAsyncClient = attrs.field(kw_only=True, repr=False, eq=False)
 
     @classmethod
     def create(
         cls,
         job: ActivatedJobResult,
-        client: "CamundaAsyncClient",
+        client: Any,
         logger: SdkLogger | None = None,
     ) -> "ConnectedJobContext":
         init_fields = {
@@ -126,13 +126,13 @@ class SyncJobContext(JobContext):
     For ``"process"`` handlers, see :class:`JobContext`.
     """
 
-    client: "CamundaClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaClient = attrs.field(kw_only=True, repr=False, eq=False)
 
     @classmethod
     def create(
         cls,
         job: ActivatedJobResult,
-        client: "CamundaClient",
+        client: Any,
         logger: SdkLogger | None = None,
     ) -> "SyncJobContext":
         init_fields = {
@@ -265,9 +265,15 @@ class _ResolvedWorkerConfig:
 class JobError(Exception):
     """Raise this exception to throw a BPMN error."""
 
-    def __init__(self, error_code: str, message: str = ""):
+    def __init__(
+        self,
+        error_code: str,
+        message: str = "",
+        variables: dict[str, Any] | None = None,
+    ):
         self.error_code = error_code
         self.message = message
+        self.variables = variables
         super().__init__(f"JobError[{error_code}]: {message}")
 
 
@@ -275,12 +281,112 @@ class JobFailure(Exception):
     """Raise this exception to explicitly fail a job with custom retries/backoff."""
 
     def __init__(
-        self, message: str, retries: int | None = None, retry_back_off: int = 0
+        self,
+        message: str,
+        retries: int | None = None,
+        retry_back_off: int = 0,
+        variables: dict[str, Any] | None = None,
     ):
         self.message = message
         self.retries = retries
         self.retry_back_off = retry_back_off
+        self.variables = variables
         super().__init__(f"JobFailure: {message}")
+
+
+class _AckFlag:
+    """Mutable flag shared between a job-scoped client wrapper and the worker dispatch."""
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = False
+
+
+class _JobScopedAsyncClient:
+    """Wraps ``CamundaAsyncClient`` to detect when a job has been explicitly
+    completed, failed, or errored by the handler \u2014 suppressing the worker's
+    automatic completion for that job."""
+
+    def __init__(
+        self,
+        client: "CamundaAsyncClient",
+        job_key: str,
+        ack: _AckFlag,
+    ) -> None:
+        object.__setattr__(self, "_inner", client)
+        object.__setattr__(self, "_job_key", job_key)
+        object.__setattr__(self, "_ack", ack)
+        object.__setattr__(self, "__wrapped__", client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+    async def complete_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").complete_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    async def fail_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").fail_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    async def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any:
+        result = await object.__getattribute__(self, "_inner").throw_job_error(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+
+class _JobScopedSyncClient:
+    """Sync equivalent of :class:`_JobScopedAsyncClient` for thread-strategy handlers."""
+
+    def __init__(
+        self,
+        client: "CamundaClient",
+        job_key: str,
+        ack: _AckFlag,
+    ) -> None:
+        object.__setattr__(self, "_inner", client)
+        object.__setattr__(self, "_job_key", job_key)
+        object.__setattr__(self, "_ack", ack)
+        object.__setattr__(self, "__wrapped__", client)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+    def complete_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").complete_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    def fail_job(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").fail_job(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
+
+    def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any:
+        result = object.__getattribute__(self, "_inner").throw_job_error(
+            job_key, **kwargs
+        )
+        if job_key == object.__getattribute__(self, "_job_key"):
+            object.__getattribute__(self, "_ack").value = True
+        return result
 
 
 def _execute_task_isolated(
@@ -311,12 +417,12 @@ def _execute_task_isolated(
         return ("complete", result)
 
     except JobError as e:
-        return ("error", (e.error_code, e.message))
+        return ("error", (e.error_code, e.message, e.variables))
     except JobFailure as e:
-        return ("fail", (e.message, e.retries, e.retry_back_off))
+        return ("fail", (e.message, e.retries, e.retry_back_off, e.variables))
     except Exception as e:
         # Catch-all for other exceptions -> Fail job
-        return ("fail", (str(e), None, 0))
+        return ("fail", (str(e), None, 0, None))
 
 
 class JobWorker:
@@ -684,11 +790,11 @@ class JobWorker:
             self.running = True
             if self._startup_jitter_max_seconds > 0:
                 jitter = random.uniform(0, self._startup_jitter_max_seconds)
-                self.logger.info(f"Delaying worker start by {jitter:.2f}s (jitter)")
+                self.logger.info(f"Worker '{self.config.worker_name}' delaying start by {jitter:.2f}s (jitter)")
                 self.polling_task = asyncio.create_task(self._start_with_jitter(jitter))
             else:
                 self.polling_task = asyncio.create_task(self.poll_loop())
-            self.logger.info("Worker started")
+            self.logger.info(f"Worker '{self.config.worker_name}' started for type '{self.config.job_type}'")
 
     async def _start_with_jitter(self, jitter: float):
         await asyncio.sleep(jitter)
@@ -713,7 +819,7 @@ class JobWorker:
             # allocated.
             self.close()
 
-            self.logger.info("Worker stopped")
+            self.logger.info(f"Worker '{self.config.worker_name}' stopped")
 
     async def aclose(self) -> None:
         """Async-aware teardown.
@@ -830,13 +936,16 @@ class JobWorker:
         # Create context with a job-scoped child logger
         job_logger = self.logger.bind(job_key=str(job_item.job_key))
         job_context: JobContext
+        ack_flag = _AckFlag()
         if self._strategy == "async":
+            wrapped_client = _JobScopedAsyncClient(self.client, job_item.job_key, ack_flag)
             job_context = ConnectedJobContext.create(
-                job_item, client=self.client, logger=job_logger
+                job_item, client=wrapped_client, logger=job_logger
             )
         elif self._strategy == "thread":
+            wrapped_sync = _JobScopedSyncClient(self._get_sync_client(), job_item.job_key, ack_flag)
             job_context = SyncJobContext.create(
-                job_item, client=self._get_sync_client(), logger=job_logger
+                job_item, client=wrapped_sync, logger=job_logger
             )
         else:
             job_context = JobContext.from_job(job_item, logger=job_logger)
@@ -865,11 +974,11 @@ class JobWorker:
                             result = sync_callback(job_context)
                         action = ("complete", result)
                     except JobError as e:
-                        action = ("error", (e.error_code, e.message))
+                        action = ("error", (e.error_code, e.message, e.variables))
                     except JobFailure as e:
-                        action = ("fail", (e.message, e.retries, e.retry_back_off))
+                        action = ("fail", (e.message, e.retries, e.retry_back_off, e.variables))
                     except Exception as e:
-                        action = ("fail", (str(e), None, 0))
+                        action = ("fail", (str(e), None, 0, None))
 
                 elif self._strategy in ["thread", "process"]:
                     # Run in Pool (Isolated)
@@ -885,7 +994,11 @@ class JobWorker:
 
                 # Handle the returned action
                 if action:
-                    if action[0] == "complete":
+                    if ack_flag.value:
+                        job_logger.debug(
+                            f"Job {job_context.job_key} already handled by handler; skipping auto-{action[0]}"
+                        )
+                    elif action[0] == "complete":
                         _, action_data = action
                         # Ensure data is in correct format
                         complete_data = JobCompletionRequest()
@@ -904,7 +1017,7 @@ class JobWorker:
                         self.logger.debug(f"Job completed: {job_context.job_key}")
 
                     elif action[0] == "fail":
-                        _, (error_message, retries, retry_back_off) = action
+                        _, (error_message, retries, retry_back_off, variables) = action
                         # Calculate retries if not provided
                         if retries is None:
                             retries = (
@@ -913,25 +1026,45 @@ class JobWorker:
                                 else 0
                             )
 
+                        fail_data = JobFailRequest(
+                            error_message=error_message,
+                            retries=retries,
+                            retry_back_off=retry_back_off,
+                        )
+                        if variables is not None:
+                            from camunda_orchestration_sdk.models.job_fail_request_variables import (
+                                JobFailRequestVariables,
+                            )
+
+                            fail_data.variables = JobFailRequestVariables.from_dict(
+                                variables
+                            )
+
                         await self.client.fail_job(
                             job_key=job_context.job_key,
-                            data=JobFailRequest(
-                                error_message=error_message,
-                                retries=retries,
-                                retry_back_off=retry_back_off,
-                            ),
+                            data=fail_data,
                         )
                         self.logger.info(
                             f"Job failed: {job_context.job_key} - {error_message}"
                         )
 
                     elif action[0] == "error":
-                        _, (error_code, error_message) = action
+                        _, (error_code, error_message, variables) = action
+                        error_data = JobErrorRequest(
+                            error_code=error_code, error_message=error_message
+                        )
+                        if variables is not None:
+                            from camunda_orchestration_sdk.models.job_error_request_variables import (
+                                JobErrorRequestVariables,
+                            )
+
+                            error_data.variables = JobErrorRequestVariables.from_dict(
+                                variables
+                            )
+
                         await self.client.throw_job_error(
                             job_key=job_context.job_key,
-                            data=JobErrorRequest(
-                                error_code=error_code, error_message=error_message
-                            ),
+                            data=error_data,
                         )
                         self.logger.info(
                             f"Job error thrown: {job_context.job_key} - {error_code}"

--- a/stubs/camunda_orchestration_sdk/runtime/job_worker.pyi
+++ b/stubs/camunda_orchestration_sdk/runtime/job_worker.pyi
@@ -9,49 +9,31 @@ from .logging import SdkLogger, NullLogger
 from camunda_orchestration_sdk.models.activated_job_result import ActivatedJobResult
 from camunda_orchestration_sdk.models.job_completion_request import JobCompletionRequest
 from camunda_orchestration_sdk import CamundaAsyncClient, CamundaClient
-
 _EFFECTIVE_EXECUTION_STRATEGY = Literal["thread", "process", "async"]
 EXECUTION_STRATEGY = _EFFECTIVE_EXECUTION_STRATEGY | Literal["auto"]
 ActionComplete = Tuple[
     Literal["complete"], Union[dict[str, Any], JobCompletionRequest, None]
 ]
-ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int]]
-ActionError = Tuple[Literal["error"], Tuple[str, str]]
+ActionFail = Tuple[Literal["fail"], Tuple[str, int | None, int, dict[str, Any] | None]]
+ActionError = Tuple[Literal["error"], Tuple[str, str, dict[str, Any] | None]]
 ActionSubprocessError = Tuple[Literal["subprocess_error"], str]
 JobAction = Union[ActionComplete, ActionFail, ActionError, ActionSubprocessError]
-
 @attrs.define
 class JobContext(ActivatedJobResult):
     log: SdkLogger = attrs.field(factory=lambda: SdkLogger(NullLogger()))
     @classmethod
-    def from_job(
-        cls, job: ActivatedJobResult, logger: SdkLogger | None = None
-    ) -> "JobContext": ...
-
+    def from_job(cls, job: ActivatedJobResult, logger: SdkLogger | None = None) -> "JobContext": ...
 @attrs.define
 class ConnectedJobContext(JobContext):
-    client: "CamundaAsyncClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaAsyncClient = attrs.field(kw_only=True, repr=False, eq=False)
     @classmethod
-    def create(
-        cls,
-        job: ActivatedJobResult,
-        client: "CamundaAsyncClient",
-        logger: SdkLogger | None = None,
-    ) -> "ConnectedJobContext": ...
-
+    def create(cls, job: ActivatedJobResult, client: CamundaAsyncClient, logger: SdkLogger | None = None) -> "ConnectedJobContext": ...
 AsyncJobContext = ConnectedJobContext
-
 @attrs.define
 class SyncJobContext(JobContext):
-    client: "CamundaClient" = attrs.field(kw_only=True, repr=False, eq=False)
+    client: CamundaClient = attrs.field(kw_only=True, repr=False, eq=False)
     @classmethod
-    def create(
-        cls,
-        job: ActivatedJobResult,
-        client: "CamundaClient",
-        logger: SdkLogger | None = None,
-    ) -> "SyncJobContext": ...
-
+    def create(cls, job: ActivatedJobResult, client: CamundaClient, logger: SdkLogger | None = None) -> "SyncJobContext": ...
 ConnectedAsyncJobHandler = Callable[
     [ConnectedJobContext],
     Coroutine[Any, Any, dict[str, Any] | JobCompletionRequest | None],
@@ -70,7 +52,6 @@ IsolatedJobHandler = IsolatedAsyncJobHandler | IsolatedSyncJobHandler
 JobHandler = ConnectedJobHandler | IsolatedJobHandler
 AsyncJobHandler = IsolatedAsyncJobHandler
 SyncJobHandler = IsolatedSyncJobHandler
-
 @dataclass
 class WorkerConfig:
     job_type: str
@@ -79,7 +60,6 @@ class WorkerConfig:
     max_concurrent_jobs: int | None = None
     fetch_variables: list[str] | None = None
     worker_name: str | None = None
-
 def resolve_worker_config(config: WorkerConfig, configuration: Any) -> WorkerConfig: ...
 @dataclass
 class _ResolvedWorkerConfig:
@@ -89,30 +69,36 @@ class _ResolvedWorkerConfig:
     max_concurrent_jobs: int
     fetch_variables: list[str] | None
     worker_name: str
-
 class JobError(Exception):
-    def __init__(self, error_code: str, message: str = "") -> None: ...
-
+    error_code: str
+    message: str
+    variables: dict[str, Any] | None
+    def __init__(self, error_code: str, message: str = "", variables: dict[str, Any] | None = None) -> None: ...
 class JobFailure(Exception):
-    def __init__(
-        self, message: str, retries: int | None = None, retry_back_off: int = 0
-    ) -> None: ...
-
-def _execute_task_isolated(
-    callback: JobHandler, job_context: JobContext
-) -> JobAction | None: ...
-
+    message: str
+    retries: int | None
+    retry_back_off: int
+    variables: dict[str, Any] | None
+    def __init__(self, message: str, retries: int | None = None, retry_back_off: int = 0, variables: dict[str, Any] | None = None) -> None: ...
+class _AckFlag:
+    __slots__ = ("value",)
+    def __init__(self) -> None: ...
+class _JobScopedAsyncClient:
+    def __init__(self, client: "CamundaAsyncClient", job_key: str, ack: _AckFlag) -> None: ...
+    def __getattr__(self, name: str) -> Any: ...
+    async def complete_job(self, job_key: Any, **kwargs: Any) -> Any: ...
+    async def fail_job(self, job_key: Any, **kwargs: Any) -> Any: ...
+    async def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any: ...
+class _JobScopedSyncClient:
+    def __init__(self, client: "CamundaClient", job_key: str, ack: _AckFlag) -> None: ...
+    def __getattr__(self, name: str) -> Any: ...
+    def complete_job(self, job_key: Any, **kwargs: Any) -> Any: ...
+    def fail_job(self, job_key: Any, **kwargs: Any) -> Any: ...
+    def throw_job_error(self, job_key: Any, **kwargs: Any) -> Any: ...
+def _execute_task_isolated(callback: JobHandler, job_context: JobContext) -> JobAction | None: ...
 class JobWorker:
     _strategy: _EFFECTIVE_EXECUTION_STRATEGY = "async"
-    def __init__(
-        self,
-        client: "CamundaAsyncClient",
-        callback: JobHandler,
-        config: WorkerConfig,
-        logger: SdkLogger | None = None,
-        execution_strategy: EXECUTION_STRATEGY = "auto",
-        startup_jitter_max_seconds: float = 0,
-    ) -> None: ...
+    def __init__(self, client: "CamundaAsyncClient", callback: JobHandler, config: WorkerConfig, logger: SdkLogger | None = None, execution_strategy: EXECUTION_STRATEGY = "auto", startup_jitter_max_seconds: float = 0) -> None: ...
     @property
     def thread_pool(self) -> ThreadPoolExecutor: ...
     @property
@@ -120,9 +106,7 @@ class JobWorker:
     @property
     def worker_loop(self) -> asyncio.AbstractEventLoop: ...
     def _run_worker_loop(self) -> None: ...
-    def _shutdown_pool(
-        self, pool: ThreadPoolExecutor | ProcessPoolExecutor
-    ) -> bool: ...
+    def _shutdown_pool(self, pool: ThreadPoolExecutor | ProcessPoolExecutor) -> bool: ...
     def close(self) -> None: ...
     def __enter__(self) -> "JobWorker": ...
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None: ...

--- a/tests/acceptance/test_connected_job_context.py
+++ b/tests/acceptance/test_connected_job_context.py
@@ -17,6 +17,8 @@ from camunda_orchestration_sdk.runtime.job_worker import (
     JobWorker,
     SyncJobContext,
     WorkerConfig,
+    _JobScopedAsyncClient,
+    _JobScopedSyncClient,
 )
 from camunda_orchestration_sdk.models.activated_job_result import ActivatedJobResult
 from camunda_orchestration_sdk.models.job_activation_result import JobActivationResult
@@ -74,7 +76,8 @@ async def test_async_strategy_provides_connected_context(
     await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
 
     assert isinstance(received_context, ConnectedJobContext)
-    assert received_context.client is mock_client
+    # client is now wrapped for autocomplete suppression
+    assert isinstance(received_context.client, _JobScopedAsyncClient)
 
 
 @pytest.mark.asyncio
@@ -95,7 +98,8 @@ async def test_thread_strategy_provides_sync_context(
     await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
 
     assert isinstance(received_context, SyncJobContext)
-    assert received_context.client is mock_sync_client
+    # client is now wrapped for autocomplete suppression
+    assert isinstance(received_context.client, _JobScopedSyncClient)
 
 
 @pytest.mark.asyncio

--- a/tests/acceptance/test_job_worker.py
+++ b/tests/acceptance/test_job_worker.py
@@ -8,6 +8,7 @@ from camunda_orchestration_sdk.runtime.job_worker import (
     JobContext,
     JobError,
     JobFailure,
+    ConnectedJobContext,
 )
 from camunda_orchestration_sdk.models.activated_job_result import (
     ActivatedJobResult,
@@ -251,3 +252,265 @@ async def test_worker_concurrency_limit(mock_client: MagicMock):
     # Verify call args for capacity
     call_args = mock_client.activate_jobs.call_args
     assert call_args.kwargs["data"].max_jobs_to_activate == 1
+
+
+# ---------------------------------------------------------------------------
+# Autocomplete suppression when handler explicitly handles the job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_suppressed_when_handler_calls_fail_job(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """When the handler calls job.client.fail_job() and returns normally,
+    the worker must NOT auto-complete the job."""
+
+    async def callback(job: ConnectedJobContext):
+        await job.client.fail_job(
+            job_key=job.job_key,
+            data=JobFailRequest(error_message="handled by handler", retries=1),
+        )
+        return {"should": "be ignored"}
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    # fail_job should have been called (through the wrapper -> mock)
+    mock_client.fail_job.assert_called_once()
+    # complete_job must NOT be called (auto-complete suppressed)
+    mock_client.complete_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_suppressed_when_handler_calls_throw_job_error(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """When the handler calls job.client.throw_job_error() and returns normally,
+    the worker must NOT auto-complete the job."""
+
+    async def callback(job: ConnectedJobContext):
+        await job.client.throw_job_error(
+            job_key=job.job_key,
+            data=JobErrorRequest(error_code="ERR_HANDLED", error_message="handled"),
+        )
+        return None
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.throw_job_error.assert_called_once()
+    mock_client.complete_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_suppressed_when_handler_calls_complete_job(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """When the handler calls job.client.complete_job() explicitly,
+    the worker must NOT auto-complete a second time."""
+
+    async def callback(job: ConnectedJobContext):
+        await job.client.complete_job(
+            job_key=job.job_key,
+            data=JobCompletionRequest(),
+        )
+        return {"extra": "data"}
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    # complete_job should only be called once (by the handler, NOT by auto-complete)
+    mock_client.complete_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ack_flag_not_set_when_api_call_fails(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """If the underlying complete_job API call raises, the ack flag must stay
+    unset so the worker can still attempt auto-fail for the job."""
+
+    mock_client.complete_job.side_effect = RuntimeError("API unavailable")
+
+    async def callback(job: ConnectedJobContext):
+        # Handler tries to complete but the API fails
+        with pytest.raises(RuntimeError, match="API unavailable"):
+            await job.client.complete_job(
+                job_key=job.job_key,
+                data=JobCompletionRequest(),
+            )
+        # Handler re-raises so the worker auto-fails
+        raise RuntimeError("complete failed")
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    # complete_job was attempted once (by handler) and raised
+    mock_client.complete_job.assert_called_once()
+    # Worker should auto-fail because ack flag was NOT set (the API call failed)
+    mock_client.fail_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ack_suppresses_auto_fail(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """When the handler explicitly completes the job and then raises,
+    the worker must NOT attempt to auto-fail — the ack flag guards
+    all terminal actions, not just complete."""
+
+    async def callback(job: ConnectedJobContext):
+        # Handler successfully completes the job...
+        await job.client.complete_job(
+            job_key=job.job_key,
+            data=JobCompletionRequest(),
+        )
+        # ...but then raises for some reason
+        raise RuntimeError("post-complete error")
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    # complete_job called once (by handler)
+    mock_client.complete_job.assert_called_once()
+    # fail_job must NOT be called — ack flag suppresses all terminal actions
+    mock_client.fail_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ack_suppresses_auto_error(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """When the handler explicitly fails the job and then raises a JobError,
+    the worker must NOT attempt to auto-throw-error."""
+
+    async def callback(job: ConnectedJobContext):
+        # Handler explicitly fails the job
+        await job.client.fail_job(
+            job_key=job.job_key,
+            data=JobFailRequest(error_message="handled", retries=0),
+        )
+        # Then raises a JobError — worker should NOT send a second terminal op
+        raise JobError("ERR", "should be ignored")
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    # fail_job called once (by handler)
+    mock_client.fail_job.assert_called_once()
+    # throw_job_error must NOT be called — ack flag suppresses
+    mock_client.throw_job_error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Variables support on JobFailure and JobError exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_job_failure_with_variables(mock_client: MagicMock, mock_job_item: JobContext):
+    """JobFailure with variables passes them through to fail_job."""
+
+    async def callback(job: JobContext):
+        raise JobFailure(
+            "Something failed",
+            retries=2,
+            retry_back_off=100,
+            variables={"errorDetail": "bad input", "retryCount": 2},
+        )
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.fail_job.assert_called_once()
+    call_args = mock_client.fail_job.call_args
+    data = call_args.kwargs["data"]
+    assert isinstance(data, JobFailRequest)
+    assert data.error_message == "Something failed"
+    assert data.retries == 2
+    assert data.retry_back_off == 100
+    assert data.variables.to_dict() == {"errorDetail": "bad input", "retryCount": 2}
+
+
+@pytest.mark.asyncio
+async def test_job_failure_without_variables_omits_field(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """JobFailure without variables does not set the variables field."""
+
+    async def callback(job: JobContext):
+        raise JobFailure("Something failed", retries=1)
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.fail_job.assert_called_once()
+    call_args = mock_client.fail_job.call_args
+    data = call_args.kwargs["data"]
+    from camunda_orchestration_sdk.types import UNSET
+
+    assert data.variables is UNSET
+
+
+@pytest.mark.asyncio
+async def test_job_error_with_variables(mock_client: MagicMock, mock_job_item: JobContext):
+    """JobError with variables passes them through to throw_job_error."""
+
+    async def callback(job: JobContext):
+        raise JobError(
+            "ERR_CODE",
+            "Business error",
+            variables={"failedItem": "order-123"},
+        )
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.throw_job_error.assert_called_once()
+    call_args = mock_client.throw_job_error.call_args
+    data = call_args.kwargs["data"]
+    assert isinstance(data, JobErrorRequest)
+    assert data.error_code == "ERR_CODE"
+    assert data.error_message == "Business error"
+    assert data.variables.to_dict() == {"failedItem": "order-123"}
+
+
+@pytest.mark.asyncio
+async def test_job_error_without_variables_omits_field(
+    mock_client: MagicMock, mock_job_item: JobContext
+):
+    """JobError without variables does not set the variables field."""
+
+    async def callback(job: JobContext):
+        raise JobError("ERR_CODE", "Business error")
+
+    config = WorkerConfig(job_type="test", job_timeout_milliseconds=1000)
+    worker = JobWorker(mock_client, callback, config)
+
+    await worker._execute_job(mock_job_item)  # pyright: ignore[reportPrivateUsage]
+
+    mock_client.throw_job_error.assert_called_once()
+    call_args = mock_client.throw_job_error.call_args
+    data = call_args.kwargs["data"]
+    from camunda_orchestration_sdk.types import UNSET
+
+    assert data.variables is UNSET


### PR DESCRIPTION
## Summary

Three improvements to the job worker runtime based on SDK review feedback.

### 1. Autocomplete suppression

When a handler explicitly calls `complete_job()`, `fail_job()`, or `throw_job_error()` on the job's client, the worker no longer auto-completes the job afterward. This prevents double-completion errors when handlers manage job lifecycle themselves.

**Implementation**: The client passed to the handler is wrapped in a lightweight proxy (`_JobScopedAsyncClient` / `_JobScopedSyncClient`) that sets an ack flag when any terminal operation is called. The worker checks this flag before auto-completing.

### 2. Variables support on `JobFailure` and `JobError`

Both exception types now accept an optional `variables: dict[str, Any] | None` parameter, allowing handlers to pass process variables when failing or erroring a job — matching the JS and C# SDKs.

```python
raise JobFailure("bad input", retries=2, variables={"errorDetail": "missing field"})
raise JobError("ERR_VALIDATION", "Invalid order", variables={"orderId": "123"})
```

### 3. Improved log messages

Worker lifecycle log messages now include the worker name for easier debugging in multi-worker setups:

```
Worker 'order-processor' started for type 'process-order'
Worker 'order-processor' stopped
```

## Testing

- 7 new acceptance tests covering autocomplete suppression and variables support
- Updated existing `test_connected_job_context.py` assertions for the new wrapper types
- All 557 tests pass