### PR TITLE
fix: adopt upstream wait-state details union in example

### DIFF
--- a/examples/extended_operations.py
+++ b/examples/extended_operations.py
@@ -11,6 +11,8 @@ from camunda_orchestration_sdk import (
     ElementInstanceSearchQuery,
     ElementInstanceWaitStateQuery,
     IncidentSearchQuery,
+    JobWaitStateDetails,
+    MessageWaitStateDetails,
     MigrateProcessInstanceMappingInstruction,
     ProcessDefinitionId,
     ProcessDefinitionInstanceStatisticsQuery,
@@ -433,10 +435,14 @@ def search_element_instance_wait_states_example() -> None:
     )
 
     for wait_state in result.items:
+        details = wait_state.details
+        if isinstance(details, JobWaitStateDetails):
+            info = f"waiting on job '{details.job_type}'"
+        else:
+            info = f"waiting for message '{details.message_name}'"
         print(
             f"Element {wait_state.element_id} "
-            f"(instance {wait_state.element_instance_key}) "
-            f"waiting in state: {wait_state.wait_state_type}"
+            f"(instance {wait_state.element_instance_key}) {info}"
         )
 
 

--- a/examples/extended_operations.py
+++ b/examples/extended_operations.py
@@ -12,7 +12,6 @@ from camunda_orchestration_sdk import (
     ElementInstanceWaitStateQuery,
     IncidentSearchQuery,
     JobWaitStateDetails,
-    MessageWaitStateDetails,
     MigrateProcessInstanceMappingInstruction,
     ProcessDefinitionId,
     ProcessDefinitionInstanceStatisticsQuery,


### PR DESCRIPTION
## Problem

CI regenerates the SDK from the live upstream spec (`make generate-local`, a prerequisite of `itest-local`) and runs `ty check examples/`. Upstream `camunda/camunda@main` restructured `ElementInstanceWaitStateResult`, replacing the flat `wait_state_type` field with a single polymorphic `details` (`WaitStateDetails`) union of `JobWaitStateDetails` / `MessageWaitStateDetails`. The committed example still reads `wait_state.wait_state_type`, so it no longer type-checks against the regenerated SDK.

This is the Python counterpart of camunda/orchestration-cluster-api-csharp#254 and camunda/orchestration-cluster-api-js#268.

## Fix

Narrow on the concrete variant via `isinstance` and read the variant-specific fields:

```python
details = wait_state.details
if isinstance(details, JobWaitStateDetails):
    info = f"waiting on job '{details.job_type}'"
else:
    info = f"waiting for message '{details.message_name}'"
```

Only the example is committed — `generated/`, `stubs/`, and the bundled spec are all regenerated by CI (`make generate-local`), and the wait-state snippet is not embedded in the README, so no other files need to change.

## Verification

Field names (`job_type`, `message_name`) and the top-level exports (`JobWaitStateDetails`, `MessageWaitStateDetails`) were taken from the committed stubs; syntax verified with `py_compile`. `uv` was not available locally to run `ty check examples/`, so the authoritative type-check is CI (which runs it after regenerating against the live spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)