### PR TITLE
fix(gen): drop discriminator-only oneOf union base models

### DIFF
--- a/hooks/post_gen/1450_drop_orphan_union_bases.py
+++ b/hooks/post_gen/1450_drop_orphan_union_bases.py
@@ -1,0 +1,196 @@
+"""Post-generation hook: drop discriminator-only ``oneOf`` union base models.
+
+Upstream models a polymorphic ``oneOf`` union by giving each variant an
+``allOf`` reference to a shared base that carries only the discriminator
+property (e.g. ``BaseWaitStateDetails`` with just ``waitStateType``).
+openapi-python-client flattens those fields into each variant, so the base
+model is emitted and exported but referenced nowhere — dead public surface.
+
+This hook detects such bases from the bundled spec and removes the generated
+model module, its stub, and every re-export. A base is removed only when it is
+*discriminator-only* and referenced nowhere except as the ``allOf`` base of the
+union's variants, so genuinely-shared mixins (bases contributing real fields,
+or referenced as a property/body/response type) are left untouched.
+
+Mirrors the C# generator fix (camunda/orchestration-cluster-api-csharp#256).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def _ref_name(node: object) -> str | None:
+    """Return the schema name of a ``$ref`` node, or ``None``."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and "/" in ref:
+            return ref.rsplit("/", 1)[-1]
+    return None
+
+
+def _load_spec(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        import yaml  # available in the generation environment
+
+        return yaml.safe_load(text)
+
+
+def _is_discriminator_only(schema: object, discriminator: str) -> bool:
+    """True if ``schema``'s sole property is the union discriminator."""
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("allOf") or schema.get("oneOf") or schema.get("anyOf"):
+        return False
+    props = schema.get("properties")
+    return isinstance(props, dict) and list(props.keys()) == [discriminator]
+
+
+def _find_orphan_bases(spec: dict) -> set[str]:
+    schemas = (spec.get("components") or {}).get("schemas") or {}
+
+    # Map each oneOf-union variant to its discriminator property.
+    union_names: set[str] = set()
+    variant_names: set[str] = set()
+    variant_discriminator: dict[str, str] = {}
+    for name, schema in schemas.items():
+        one_of = schema.get("oneOf")
+        disc = schema.get("discriminator")
+        if not (isinstance(one_of, list) and one_of and isinstance(disc, dict)):
+            continue
+        prop = disc.get("propertyName")
+        variants = [_ref_name(v) for v in one_of]
+        if not prop or any(v is None for v in variants):
+            continue
+        union_names.add(name)
+        for variant in variants:
+            variant_names.add(variant)
+            variant_discriminator.setdefault(variant, prop)
+
+    # Candidate bases: discriminator-only schemas pulled into a variant via allOf.
+    candidates: set[str] = set()
+    for variant, prop in variant_discriminator.items():
+        for entry in schemas.get(variant, {}).get("allOf") or []:
+            base = _ref_name(entry)
+            if base and _is_discriminator_only(schemas.get(base), prop):
+                candidates.add(base)
+    if not candidates:
+        return set()
+
+    # Collect every reference EXCEPT a variant's allOf ref to a candidate base;
+    # any other reference is a genuine use that disqualifies suppression.
+    referenced: set[str] = set()
+
+    def collect(node: object) -> None:
+        if isinstance(node, dict):
+            ref = _ref_name(node)
+            if ref is not None:
+                referenced.add(ref)
+                return
+            for value in node.values():
+                collect(value)
+        elif isinstance(node, list):
+            for item in node:
+                collect(item)
+
+    for name, schema in schemas.items():
+        is_variant = name in variant_names
+        for key, value in schema.items():
+            if key == "allOf" and is_variant and isinstance(value, list):
+                for entry in value:
+                    base = _ref_name(entry)
+                    if base and base in candidates:
+                        continue  # the suppressible discriminator-base ref
+                    collect(entry)
+            else:
+                collect(value)
+
+    # Operation parameters, request bodies, and responses are real uses too.
+    collect(spec.get("paths") or {})
+
+    return {
+        base
+        for base in candidates
+        if base not in referenced
+        and base not in union_names
+        and base not in variant_names
+    }
+
+
+def _class_to_module(models_init: Path) -> dict[str, str]:
+    """Map exported class name -> model module, parsed from models/__init__.py."""
+    mapping: dict[str, str] = {}
+    for line in models_init.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"\s*from \.(\w+) import (\w+)\s*$", line)
+        if match:
+            mapping[match.group(2)] = match.group(1)
+    return mapping
+
+
+def _strip_symbol(path: Path, class_name: str, module: str) -> None:
+    """Remove the import and ``__all__`` entries for a symbol from an init file."""
+    if not path.exists():
+        return
+    drop = {
+        f'"{class_name}",',
+        f'"{class_name}"',
+        f"{class_name},",
+        f"from .{module} import {class_name}",
+    }
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    kept = [line for line in lines if line.strip() not in drop]
+    if len(kept) != len(lines):
+        path.write_text("".join(kept), encoding="utf-8")
+
+
+def run(context: dict[str, str]) -> None:
+    bundled = context.get("bundled_spec_path")
+    if not bundled or not Path(bundled).exists():
+        print("drop-orphan-union-bases: no bundled spec, skipping")
+        return
+
+    out_dir = Path(context["out_dir"])
+    package = out_dir / "camunda_orchestration_sdk"
+    models_init = package / "models" / "__init__.py"
+    if not models_init.exists():
+        print("drop-orphan-union-bases: models/__init__.py not found, skipping")
+        return
+
+    orphans = _find_orphan_bases(_load_spec(Path(bundled)))
+    if not orphans:
+        print("drop-orphan-union-bases: no orphan union bases found")
+        return
+
+    class_to_module = _class_to_module(models_init)
+    stubs_package = out_dir.parent / "stubs" / "camunda_orchestration_sdk"
+
+    removed: list[str] = []
+    for class_name in sorted(orphans):
+        module = class_to_module.get(class_name)
+        if module is None:
+            # Cannot map the schema to a generated module; leave it untouched.
+            continue
+        for model_file in (
+            package / "models" / f"{module}.py",
+            stubs_package / "models" / f"{module}.pyi",
+        ):
+            if model_file.exists():
+                model_file.unlink()
+        for init_file in (
+            package / "models" / "__init__.py",
+            package / "__init__.py",
+            stubs_package / "models" / "__init__.pyi",
+            stubs_package / "__init__.pyi",
+        ):
+            _strip_symbol(init_file, class_name, module)
+        removed.append(class_name)
+
+    if removed:
+        print(f"drop-orphan-union-bases: removed {', '.join(removed)}")
+    else:
+        print("drop-orphan-union-bases: no mappable orphan bases to remove")

--- a/hooks/post_gen/1450_drop_orphan_union_bases.py
+++ b/hooks/post_gen/1450_drop_orphan_union_bases.py
@@ -20,18 +20,32 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from typing import Any, cast
+
+
+def _get(obj: object, key: str) -> Any:
+    """``obj.get(key)`` when ``obj`` is a mapping, else ``None`` (typed ``Any``)."""
+    if isinstance(obj, dict):
+        return cast("dict[str, Any]", obj).get(key)
+    return None
+
+
+def _items(obj: object) -> list[tuple[str, Any]]:
+    """Items of a mapping with string keys, or empty when ``obj`` is not one."""
+    if isinstance(obj, dict):
+        return [(k, v) for k, v in cast("dict[str, Any]", obj).items() if isinstance(k, str)]
+    return []
 
 
 def _ref_name(node: object) -> str | None:
     """Return the schema name of a ``$ref`` node, or ``None``."""
-    if isinstance(node, dict):
-        ref = node.get("$ref")
-        if isinstance(ref, str) and "/" in ref:
-            return ref.rsplit("/", 1)[-1]
+    ref = _get(node, "$ref")
+    if isinstance(ref, str) and "/" in ref:
+        return ref.rsplit("/", 1)[-1]
     return None
 
 
-def _load_spec(path: Path) -> dict:
+def _load_spec(path: Path) -> Any:
     text = path.read_text(encoding="utf-8")
     try:
         return json.loads(text)
@@ -45,28 +59,32 @@ def _is_discriminator_only(schema: object, discriminator: str) -> bool:
     """True if ``schema``'s sole property is the union discriminator."""
     if not isinstance(schema, dict):
         return False
-    if schema.get("allOf") or schema.get("oneOf") or schema.get("anyOf"):
+    if _get(schema, "allOf") or _get(schema, "oneOf") or _get(schema, "anyOf"):
         return False
-    props = schema.get("properties")
+    props = _get(schema, "properties")
     return isinstance(props, dict) and list(props.keys()) == [discriminator]
 
 
-def _find_orphan_bases(spec: dict) -> set[str]:
-    schemas = (spec.get("components") or {}).get("schemas") or {}
+def _find_orphan_bases(spec: object) -> set[str]:
+    schemas = _get(_get(spec, "components"), "schemas")
+    if not isinstance(schemas, dict):
+        return set()
 
     # Map each oneOf-union variant to its discriminator property.
     union_names: set[str] = set()
     variant_names: set[str] = set()
     variant_discriminator: dict[str, str] = {}
-    for name, schema in schemas.items():
-        one_of = schema.get("oneOf")
-        disc = schema.get("discriminator")
+    for name, schema in _items(schemas):
+        one_of = _get(schema, "oneOf")
+        disc = _get(schema, "discriminator")
         if not (isinstance(one_of, list) and one_of and isinstance(disc, dict)):
             continue
-        prop = disc.get("propertyName")
-        variants = [_ref_name(v) for v in one_of]
-        if not prop or any(v is None for v in variants):
+        prop = _get(disc, "propertyName")
+        if not isinstance(prop, str):
             continue
+        variants = [r for r in (_ref_name(v) for v in one_of) if isinstance(r, str)]
+        if len(variants) != len(one_of):
+            continue  # some oneOf entry was not a plain $ref
         union_names.add(name)
         for variant in variants:
             variant_names.add(variant)
@@ -75,9 +93,12 @@ def _find_orphan_bases(spec: dict) -> set[str]:
     # Candidate bases: discriminator-only schemas pulled into a variant via allOf.
     candidates: set[str] = set()
     for variant, prop in variant_discriminator.items():
-        for entry in schemas.get(variant, {}).get("allOf") or []:
+        all_of = _get(_get(schemas, variant), "allOf")
+        if not isinstance(all_of, list):
+            continue
+        for entry in all_of:
             base = _ref_name(entry)
-            if base and _is_discriminator_only(schemas.get(base), prop):
+            if base and _is_discriminator_only(_get(schemas, base), prop):
                 candidates.add(base)
     if not candidates:
         return set()
@@ -92,15 +113,15 @@ def _find_orphan_bases(spec: dict) -> set[str]:
             if ref is not None:
                 referenced.add(ref)
                 return
-            for value in node.values():
+            for _key, value in _items(node):
                 collect(value)
         elif isinstance(node, list):
             for item in node:
                 collect(item)
 
-    for name, schema in schemas.items():
+    for name, schema in _items(schemas):
         is_variant = name in variant_names
-        for key, value in schema.items():
+        for key, value in _items(schema):
             if key == "allOf" and is_variant and isinstance(value, list):
                 for entry in value:
                     base = _ref_name(entry)
@@ -111,7 +132,7 @@ def _find_orphan_bases(spec: dict) -> set[str]:
                 collect(value)
 
     # Operation parameters, request bodies, and responses are real uses too.
-    collect(spec.get("paths") or {})
+    collect(_get(spec, "paths"))
 
     return {
         base

--- a/hooks/post_gen/1450_drop_orphan_union_bases.py
+++ b/hooks/post_gen/1450_drop_orphan_union_bases.py
@@ -17,6 +17,7 @@ Mirrors the C# generator fix (camunda/orchestration-cluster-api-csharp#256).
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 from pathlib import Path
@@ -144,29 +145,43 @@ def _find_orphan_bases(spec: object) -> set[str]:
 
 
 def _class_to_module(models_init: Path) -> dict[str, str]:
-    """Map exported class name -> model module, parsed from models/__init__.py."""
+    """Map exported class name -> model module from models/__init__.py.
+
+    Uses the AST so both single-line ``from .mod import Class`` and
+    parenthesised multi-line ``from .mod import (Class,)`` imports are handled.
+    """
+    tree = ast.parse(models_init.read_text(encoding="utf-8"))
     mapping: dict[str, str] = {}
-    for line in models_init.read_text(encoding="utf-8").splitlines():
-        match = re.match(r"\s*from \.(\w+) import (\w+)\s*$", line)
-        if match:
-            mapping[match.group(2)] = match.group(1)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+            for alias in node.names:
+                mapping[alias.asname or alias.name] = node.module
     return mapping
 
 
 def _strip_symbol(path: Path, class_name: str, module: str) -> None:
-    """Remove the import and ``__all__`` entries for a symbol from an init file."""
+    """Remove the import and ``__all__`` entry for a symbol from an init file.
+
+    Handles the single-line ``from .mod import Class`` and the parenthesised
+    multi-line ``from .mod import (\\n    Class,\\n)`` dedicated imports
+    (openapi-python-client uses the latter for long names), the ``"Class",``
+    ``__all__`` entry, and a ``Class,`` member inside a shared grouped import.
+    """
     if not path.exists():
         return
-    drop = {
-        f'"{class_name}",',
-        f'"{class_name}"',
-        f"{class_name},",
-        f"from .{module} import {class_name}",
-    }
-    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
-    kept = [line for line in lines if line.strip() not in drop]
-    if len(kept) != len(lines):
-        path.write_text("".join(kept), encoding="utf-8")
+    cls = re.escape(class_name)
+    mod = re.escape(module)
+    text = original = path.read_text(encoding="utf-8")
+    # Dedicated single-line import.
+    text = re.sub(rf"(?m)^from \.{mod} import {cls}[ \t]*\n", "", text)
+    # Dedicated multi-line import block importing only this class.
+    text = re.sub(rf"(?m)^from \.{mod} import \(\n[ \t]*{cls},?[ \t]*\n\)[ \t]*\n", "", text)
+    # __all__ entry (quoted).
+    text = re.sub(rf'(?m)^[ \t]*"{cls}",?[ \t]*\n', "", text)
+    # Member of a shared grouped import (unquoted).
+    text = re.sub(rf"(?m)^[ \t]*{cls},[ \t]*\n", "", text)
+    if text != original:
+        path.write_text(text, encoding="utf-8")
 
 
 def run(context: dict[str, str]) -> None:

--- a/tests/acceptance/test_hook_drop_orphan_union_bases.py
+++ b/tests/acceptance/test_hook_drop_orphan_union_bases.py
@@ -1,0 +1,240 @@
+"""Tests for hooks/post_gen/1450_drop_orphan_union_bases.py.
+
+Regression guards for the orphan discriminator-only union-base cleanup. The
+detection runs against synthetic specs, and the init-file rewriting runs
+against synthetic snippets (single-line and parenthesised multi-line import
+forms), so the guards stay meaningful regardless of the current upstream spec.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+# Import the numbered hook module via importlib (filename starts with a digit).
+_hook_path = (
+    Path(__file__).resolve().parents[2]
+    / "hooks"
+    / "post_gen"
+    / "1450_drop_orphan_union_bases.py"
+)
+_spec = importlib.util.spec_from_file_location("_drop_orphan_union_bases", _hook_path)
+assert _spec and _spec.loader
+_hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_hook)
+
+_find_orphan_bases = _hook._find_orphan_bases
+_class_to_module = _hook._class_to_module
+_strip_symbol = _hook._strip_symbol
+
+
+def _object_schema(props: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    return {"type": "object", "required": required, "properties": props}
+
+
+def _union(discriminator: str, mapping: dict[str, str]) -> dict[str, Any]:
+    return {
+        "discriminator": {"propertyName": discriminator, "mapping": mapping},
+        "oneOf": [{"$ref": f"#/components/schemas/{v}"} for v in mapping.values()],
+    }
+
+
+class TestFindOrphanBases:
+    def _spec(self) -> dict[str, Any]:
+        schemas: dict[str, Any] = {
+            # Union 1: discriminator-only base referenced ONLY by its variants.
+            "Pet": _union("petType", {"CAT": "Cat", "DOG": "Dog"}),
+            "BasePet": _object_schema({"petType": {"type": "string"}}, ["petType"]),
+            "Cat": {
+                "type": "object",
+                "required": ["petType", "meow"],
+                "allOf": [
+                    {"$ref": "#/components/schemas/BasePet"},
+                    # A shared mixin with real fields, composed alongside the base.
+                    {"$ref": "#/components/schemas/Timestamped"},
+                ],
+                "properties": {"meow": {"type": "string"}},
+            },
+            "Dog": {
+                "type": "object",
+                "required": ["petType"],
+                "allOf": [{"$ref": "#/components/schemas/BasePet"}],
+                "properties": {"bark": {"type": "string"}},
+            },
+            "Timestamped": _object_schema(
+                {"createdAt": {"type": "string"}}, ["createdAt"]
+            ),
+            # Union 2: discriminator-only base ALSO referenced by a property.
+            "Vehicle": _union("vehicleType", {"CAR": "Car", "TRUCK": "Truck"}),
+            "BaseVehicle": _object_schema(
+                {"vehicleType": {"type": "string"}}, ["vehicleType"]
+            ),
+            "Car": {
+                "type": "object",
+                "required": ["vehicleType"],
+                "allOf": [{"$ref": "#/components/schemas/BaseVehicle"}],
+                "properties": {"doors": {"type": "integer"}},
+            },
+            "Truck": {
+                "type": "object",
+                "required": ["vehicleType"],
+                "allOf": [{"$ref": "#/components/schemas/BaseVehicle"}],
+                "properties": {"axles": {"type": "integer"}},
+            },
+            "Garage": _object_schema(
+                {"spec": {"$ref": "#/components/schemas/BaseVehicle"}}, []
+            ),
+            # Union 3: discriminator-only base referenced ONLY by a response body.
+            "Shape": _union("shapeType", {"BOX": "Box", "SPHERE": "Sphere"}),
+            "BaseShape": _object_schema(
+                {"shapeType": {"type": "string"}}, ["shapeType"]
+            ),
+            "Box": {
+                "type": "object",
+                "required": ["shapeType"],
+                "allOf": [{"$ref": "#/components/schemas/BaseShape"}],
+                "properties": {"width": {"type": "integer"}},
+            },
+            "Sphere": {
+                "type": "object",
+                "required": ["shapeType"],
+                "allOf": [{"$ref": "#/components/schemas/BaseShape"}],
+                "properties": {"radius": {"type": "integer"}},
+            },
+        }
+        return {
+            "components": {"schemas": schemas},
+            "paths": {
+                "/shapes/base": {
+                    "get": {
+                        "operationId": "getShapeBase",
+                        "responses": {
+                            "200": {
+                                "description": "ok",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/BaseShape"
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+    def test_only_truly_orphan_discriminator_base_is_reported(self) -> None:
+        orphans = _find_orphan_bases(self._spec())
+
+        # BasePet is referenced only as the allOf base of Cat/Dog -> orphan.
+        assert orphans == {"BasePet"}, orphans
+
+    def test_referenced_and_mixin_bases_are_preserved(self) -> None:
+        orphans = _find_orphan_bases(self._spec())
+
+        # Referenced via a property (BaseVehicle), via a response body
+        # (BaseShape), and a real mixin composed via allOf (Timestamped).
+        assert "BaseVehicle" not in orphans
+        assert "BaseShape" not in orphans
+        assert "Timestamped" not in orphans
+
+    def test_no_unions_yields_no_orphans(self) -> None:
+        assert _find_orphan_bases({"components": {"schemas": {}}}) == set()
+
+
+class TestClassToModule:
+    def test_maps_single_and_multi_line_imports(self, tmp_path: Path) -> None:
+        models_init = tmp_path / "__init__.py"
+        models_init.write_text(
+            "from .base_pet import BasePet\n"
+            "from .some_very_long_module_name import (\n"
+            "    SomeVeryLongClassName,\n"
+            ")\n"
+            '__all__ = ["BasePet", "SomeVeryLongClassName"]\n',
+            encoding="utf-8",
+        )
+
+        mapping = _class_to_module(models_init)
+
+        assert mapping["BasePet"] == "base_pet"
+        assert mapping["SomeVeryLongClassName"] == "some_very_long_module_name"
+
+
+class TestStripSymbol:
+    def test_removes_single_line_dedicated_import_and_all_entry(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "__init__.py"
+        path.write_text(
+            "from .base_pet import BasePet\n"
+            "from .other import Other\n"
+            '__all__ = [\n    "BasePet",\n    "Other",\n]\n',
+            encoding="utf-8",
+        )
+
+        _strip_symbol(path, "BasePet", "base_pet")
+        result = path.read_text(encoding="utf-8")
+
+        assert "BasePet" not in result
+        assert "from .other import Other" in result
+        assert '"Other",' in result
+
+    def test_removes_multiline_dedicated_import_block_without_leaving_stub(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "__init__.py"
+        path.write_text(
+            "from .base_pet import (\n    BasePet,\n)\n"
+            "from .other import Other\n"
+            '__all__ = [\n    "BasePet",\n    "Other",\n]\n',
+            encoding="utf-8",
+        )
+
+        _strip_symbol(path, "BasePet", "base_pet")
+        result = path.read_text(encoding="utf-8")
+
+        assert "BasePet" not in result
+        # No stale empty import block left behind.
+        assert "from .base_pet import" not in result
+        assert "import (\n)" not in result
+        assert "from .other import Other" in result
+
+    def test_removes_member_from_shared_grouped_import(self, tmp_path: Path) -> None:
+        path = tmp_path / "__init__.py"
+        path.write_text(
+            "from camunda_orchestration_sdk.models import (\n"
+            "    Alpha,\n"
+            "    BasePet,\n"
+            "    Beta,\n"
+            ")\n"
+            '__all__: list[str] = [\n    "Alpha",\n    "BasePet",\n    "Beta",\n]\n',
+            encoding="utf-8",
+        )
+
+        _strip_symbol(path, "BasePet", "base_pet")
+        result = path.read_text(encoding="utf-8")
+
+        assert "BasePet" not in result
+        assert "Alpha," in result
+        assert "Beta," in result
+        assert '"Alpha",' in result
+        assert '"Beta",' in result
+
+    def test_does_not_strip_prefixed_sibling_symbols(self, tmp_path: Path) -> None:
+        path = tmp_path / "__init__.py"
+        path.write_text(
+            "from .base_pet import BasePet\n"
+            "from .base_pet_extended import BasePetExtended\n"
+            '__all__ = [\n    "BasePet",\n    "BasePetExtended",\n]\n',
+            encoding="utf-8",
+        )
+
+        _strip_symbol(path, "BasePet", "base_pet")
+        result = path.read_text(encoding="utf-8")
+
+        assert "from .base_pet_extended import BasePetExtended" in result
+        assert '"BasePetExtended",' in result
+        assert "from .base_pet import BasePet" not in result


### PR DESCRIPTION
## Problem

Upstream models a polymorphic `oneOf` union by giving each variant an `allOf` reference to a shared base that carries only the discriminator (e.g. `BaseWaitStateDetails`, whose only property is `waitStateType`). `openapi-python-client` flattens those fields into each variant, so the base model is generated and exported in `__all__` but **referenced nowhere** — dead public API surface.

This is the Python counterpart of camunda/orchestration-cluster-api-csharp#256 (and the issue it closed, #255). JS is unaffected — there the base is referenced via TypeScript intersection types.

A `git grep` confirms it: the only references to `BaseWaitStateDetails` are its own module and the package/model `__init__` export machinery — nothing uses it.

## Fix

Add a post-gen hook (`hooks/post_gen/1450_drop_orphan_union_bases.py`) that, after generation, detects discriminator-only union bases from the bundled spec and removes the generated model module, its stub, and every re-export.

Detection mirrors the C# fix: a base is removed only when it is **discriminator-only** (its sole property is the union's discriminator) **and** referenced nowhere except as the `allOf` base of the union's variants. The reference scan covers component schemas (skipping only the variant→discriminator-base `allOf` edge) plus operation parameters, request bodies, and responses — so shared mixins and bases used as a property/body/response type are preserved.

Only the hook is committed; `generated/` and `stubs/` are regenerated by CI (`make generate-local`), and generation drift is non-blocking — same approach as the wait-state example PRs.

## Verification

Ran the hook locally with stdlib Python against the current generated tree + bundled spec:

- Removed exactly `BaseWaitStateDetails`; **zero** residual references across `generated/` and `stubs/`.
- Model `.py` and stub `.pyi` deleted; the four `__init__` files lose only the import + `__all__` entry (verified `ast.parse`s cleanly).
- Variants (`JobWaitStateDetails`/`MessageWaitStateDetails`) and unrelated bases (`BaseProcessInstanceFilterFields`) untouched.

`uv` wasn't available locally to run the full `make generate`/`ty`, so CI is the authoritative check (it runs the hook during regeneration, then type-checks and tests against the result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)