### PR TITLE
docs: add restore example coverage

### DIFF
--- a/examples/admin_operations.py
+++ b/examples/admin_operations.py
@@ -35,6 +35,7 @@ from camunda_orchestration_sdk import (
     JobWorkerStatisticsQuery,
     MessageSubscriptionSearchQuery,
     ResourceSearchQuery,
+    RestoreRequest,
     TenantId,
     Unset,
     UpdateClusterVariableRequest,
@@ -281,6 +282,24 @@ def change_cluster_mode_example() -> None:
         suffix = f" -> {operation.mode}" if operation.mode else ""
         print(f"  {operation.operation}{suffix}")
 # endregion ChangeClusterMode
+
+
+# region Restore
+def restore_example() -> None:
+    client = CamundaClient()
+
+    # The cluster must be in recovery mode before a restore is accepted. Provide
+    # either a list of backup IDs (one per partition) or a time range (from_/to)
+    # that selects the backups to restore, but not both.
+    result = client.restore(
+        data=RestoreRequest(backup_ids=[100, 101]),
+    )
+
+    print(f"Cluster change {result.change_id}:")
+    for operation in result.planned_changes:
+        suffix = f" -> {operation.mode}" if operation.mode else ""
+        print(f"  {operation.operation}{suffix}")
+# endregion Restore
 
 
 # region GetStatus

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -55,6 +55,13 @@
             "label": "Change cluster mode"
         }
     ],
+    "restore": [
+        {
+            "file": "admin_operations.py",
+            "region": "Restore",
+            "label": "Restore from a backup"
+        }
+    ],
     "get_status": [
         {
             "file": "admin_operations.py",


### PR DESCRIPTION
## Description

Adds example coverage for the `restore` operation (`POST /restore`, tag `Recovery`, added in 8.10), closing the coverage gap reported in #197.

- Add a `Restore` region example to `examples/admin_operations.py` (Recovery domain, alongside `ChangeClusterMode`), calling `client.restore(data=RestoreRequest(backup_ids=[...]))` and noting the `from_`/`to` time-range alternative.
- Add the `restore` entry to `examples/operation-map.json`.

Following the same convention as the merged `change_cluster_mode` example PR, this touches only the two hand-written example files. Generated code (`generated/`, `stubs/`) and the bundled spec are regenerated fresh by CI and are intentionally not committed here.

## Verification

Validated locally by regenerating the SDK from the latest upstream spec (not committed):
- `ty check examples/` — example type-checks against the generated `restore(*, data: RestoreRequest)` method
- `check_example_coverage.py` — 100% (197/197), integrity check passes
- `ruff check` on the example — clean
- `pytest tests/acceptance` — 509 passed, 1 skipped

Closes #197
