### PR TITLE
docs: add search_process_definition_variable_names example coverage

### DIFF
--- a/examples/extended_operations.py
+++ b/examples/extended_operations.py
@@ -249,6 +249,24 @@ def search_process_definitions_example() -> None:
 # endregion SearchProcessDefinitions
 
 
+# region SearchProcessDefinitionVariableNames
+def search_process_definition_variable_names_example(
+    process_definition_key: ProcessDefinitionKey,
+) -> None:
+    client = CamundaClient()
+
+    result = client.search_process_definition_variable_names(
+        process_definition_key=process_definition_key,
+    )
+
+    if not isinstance(result.items, Unset):
+        for variable in result.items:
+            print(f"Variable name: {variable.name}")
+
+
+# endregion SearchProcessDefinitionVariableNames
+
+
 # region GetProcessDefinitionStatistics
 def get_process_definition_statistics_example(
     process_definition_key: ProcessDefinitionKey,

--- a/examples/extended_operations.py
+++ b/examples/extended_operations.py
@@ -21,6 +21,7 @@ from camunda_orchestration_sdk import (
     ProcessDefinitionKey,
     ProcessDefinitionMessageSubscriptionStatisticsQuery,
     ProcessDefinitionSearchQuery,
+    ProcessDefinitionVariableNameSearchQuery,
     ProcessInstanceKey,
     ProcessInstanceMigrationInstruction,
     ProcessInstanceModificationInstruction,
@@ -257,6 +258,7 @@ def search_process_definition_variable_names_example(
 
     result = client.search_process_definition_variable_names(
         process_definition_key=process_definition_key,
+        data=ProcessDefinitionVariableNameSearchQuery(),
     )
 
     if not isinstance(result.items, Unset):

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -909,6 +909,13 @@
             "label": "Search process definitions"
         }
     ],
+    "search_process_definition_variable_names": [
+        {
+            "file": "extended_operations.py",
+            "region": "SearchProcessDefinitionVariableNames",
+            "label": "Search process definition variable names"
+        }
+    ],
     "get_process_definition_statistics": [
         {
             "file": "extended_operations.py",


### PR DESCRIPTION
## Description

Adds example coverage for the `searchProcessDefinitionVariableNames` operation (`POST /process-definitions/{processDefinitionKey}/variable-names/search`, tag `Process definition`, added in 8.10), closing the coverage gap reported in #199.

- Add a `SearchProcessDefinitionVariableNames` region example to `examples/extended_operations.py` (alongside `SearchProcessDefinitions`), calling `client.search_process_definition_variable_names(process_definition_key=...)` and printing each `variable.name`.
- Add the `search_process_definition_variable_names` entry to `examples/operation-map.json`.

Following the same convention as the merged `change_cluster_mode` example PR, this touches only the two hand-written example files. Generated code (`generated/`, `stubs/`) and the bundled spec are regenerated fresh by CI and are intentionally not committed here.

## Verification

Validated locally by regenerating the SDK from the latest upstream spec (not committed):
- `ty check examples/` — example type-checks against the generated `search_process_definition_variable_names(process_definition_key, *, data)` method
- `ruff check` on the example — clean
- `check_example_coverage.py` — 100% (198/198), integrity check passes

Closes #199
