### PR TITLE
docs: fix API reference rendering of signatures, blockquotes and params

### DIFF
--- a/examples/admin_operations.py
+++ b/examples/admin_operations.py
@@ -289,7 +289,7 @@ def restore_example() -> None:
     client = CamundaClient()
 
     # The cluster must be in recovery mode before a restore is accepted. Provide
-    # either a list of backup IDs (one per partition) or a time range (from_/to)
+    # either a list of backup IDs (one per partition) or a time range (from/to)
     # that selects the backups to restore, but not both.
     result = client.restore(
         data=RestoreRequest(backup_ids=[100, 101]),

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -18,6 +18,48 @@ def to_camel_case(snake_str: str) -> str:
     return components[0] + "".join(x.title() for x in components[1:])
 
 
+_DOCSTRING_ARGS_HEADER = re.compile(r"^\s*(?:Args|Arguments|Parameters):\s*$")
+_DOCSTRING_SECTION_HEADER = re.compile(r"^\s*\w[\w ]*:\s*$")
+_DOCSTRING_BODY_ARG = re.compile(r"^(\s+)body(\s*[:(])")
+
+
+def _rename_body_arg_in_docstring(docstring: str | None) -> str | None:
+    """Rename the ``body`` parameter to ``data`` in a docstring ``Args:`` section.
+
+    The flattened client renames the generated ``body`` request-model parameter
+    to ``data`` in the method signature, but the docstring is emitted verbatim
+    and still documents ``body``. That leaves the rendered API reference showing
+    both an undocumented ``data`` parameter and a documented ``body`` parameter
+    that no longer exists. Rename the documented entry to match the signature.
+
+    The rename is scoped to the ``Args:`` section (Google-style docstrings) and
+    only rewrites the leading parameter-name token, so prose mentioning the word
+    "body" elsewhere is untouched.
+    """
+    if not docstring or "body" not in docstring:
+        return docstring
+    lines = docstring.split("\n")
+    in_args = False
+    args_indent = 0
+    for idx, line in enumerate(lines):
+        if _DOCSTRING_ARGS_HEADER.match(line):
+            in_args = True
+            args_indent = len(line) - len(line.lstrip())
+            continue
+        if not in_args:
+            continue
+        if line.strip() == "":
+            continue
+        indent = len(line) - len(line.lstrip())
+        # A section header at (or before) the Args indent ends the Args block.
+        if indent <= args_indent and _DOCSTRING_SECTION_HEADER.match(line):
+            break
+        if _DOCSTRING_BODY_ARG.match(line):
+            lines[idx] = _DOCSTRING_BODY_ARG.sub(r"\1data\2", line, count=1)
+            break
+    return "\n".join(lines)
+
+
 ImportNode = ast.Import | ast.ImportFrom
 
 
@@ -721,7 +763,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                 return_ann = (
                     f" -> {ast.unparse(sync_func.returns)}" if sync_func.returns else ""
                 )
-                docstring = ast.get_docstring(sync_func)
+                docstring = _rename_body_arg_in_docstring(ast.get_docstring(sync_func))
                 docstring_str = f'        """{safe_docstring(docstring)}"""\n' if docstring else ""
 
                 # Body-tenant injection: for operations where tenantId is an optional
@@ -885,7 +927,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                     if async_func.returns
                     else ""
                 )
-                docstring = ast.get_docstring(async_func)
+                docstring = _rename_body_arg_in_docstring(ast.get_docstring(async_func))
                 docstring_str = f'        """{safe_docstring(docstring)}"""\n' if docstring else ""
 
                 # Body-tenant injection: same logic as sync methods

--- a/scripts/postprocess_markdown.py
+++ b/scripts/postprocess_markdown.py
@@ -63,6 +63,33 @@ def _unescape_for_code(text: str) -> str:
     return text.replace("\\*", "*")
 
 
+def _restore_keyword_only_marker(params: str) -> str:
+    """Restore the bare ``*`` keyword-only separator dropped by the markdown builder.
+
+    ``sphinx-markdown-builder`` does not know how to render the bare ``*``
+    keyword-only marker in a signature (it emits the warning
+    ``unknown node type: <abbreviation: <#text: '*'>>`` and drops the node),
+    leaving an empty comma slot in the rendered signature, e.g.::
+
+        restore(, data, **kwargs)
+        update_tenant(tenant_id, , data, **kwargs)
+
+    Each empty comma-separated slot corresponds to exactly one dropped ``*``
+    marker, so we put it back::
+
+        restore(*, data, **kwargs)
+        update_tenant(tenant_id, *, data, **kwargs)
+
+    Signatures with no parameters (``run_workers()``) are left untouched so we
+    never synthesise a spurious ``(*)``.
+    """
+    if not params.strip():
+        return params
+    parts = [segment.strip() for segment in params.split(",")]
+    parts = [segment if segment else "*" for segment in parts]
+    return ", ".join(parts)
+
+
 def simplify_class_heading(match: re.Match[str]) -> str:
     """Transform class heading: keep simple name, move full signature to code block."""
     hashes = match.group(1)
@@ -82,7 +109,7 @@ def simplify_method_heading(match: re.Match[str]) -> str:
     hashes = match.group(1)
     async_marker = match.group(2) or ""
     method_name = match.group(3)
-    params = _unescape_for_code(match.group(4))
+    params = _restore_keyword_only_marker(_unescape_for_code(match.group(4)))
     return_type = _unescape_for_code(match.group(5) or "")
 
     async_prefix = "async " if async_marker else ""
@@ -174,6 +201,159 @@ def rewrite_camunda_docs_links(content: str, depth: int = DEPLOYMENT_DEPTH) -> s
     )
 
 
+# Structural boundaries that terminate a method-description blockquote: field
+# lists (``* **Parameters:**``), bullet/ordered lists, headings, code fences,
+# tables, and admonitions.
+_BLOCKQUOTE_BOUNDARY = re.compile(r"^\s*(?:[*+-] |#{1,6} |```|~~~|\||:::|\d+\. )")
+
+
+def fix_description_blockquotes(content: str) -> str:
+    """Fold description continuation paragraphs back into their blockquote.
+
+    ``sphinx-markdown-builder`` renders a method description's first paragraph
+    as a blockquote (``> ...``) but emits any following paragraphs flush-left,
+    so they render as plain text *outside* the blockquote. Re-prefix those
+    continuation paragraphs with ``>`` so the whole description stays in one
+    blockquote, stopping at the first structural boundary (field list, heading,
+    code fence, table, admonition).
+    """
+    lines = content.split("\n")
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if not line.startswith(">"):
+            out.append(line)
+            i += 1
+            continue
+
+        # Emit the initial run of blockquote lines.
+        while i < n and lines[i].startswith(">"):
+            out.append(lines[i])
+            i += 1
+
+        # Fold any blank-separated continuation paragraphs into the blockquote,
+        # up to the first structural boundary.
+        while True:
+            blank_start = i
+            while i < n and lines[i].strip() == "":
+                i += 1
+            if i >= n or _BLOCKQUOTE_BOUNDARY.match(lines[i]):
+                out.extend(lines[blank_start:i])
+                break
+            # Separate paragraphs inside the blockquote with an empty quote line.
+            out.append(">")
+            while (
+                i < n
+                and lines[i].strip() != ""
+                and not lines[i].startswith(">")
+                and not _BLOCKQUOTE_BOUNDARY.match(lines[i])
+            ):
+                out.append("> " + lines[i])
+                i += 1
+    return "\n".join(out)
+
+
+# A field-list parameter item: ``  * **name** (type) – description``. The type
+# is captured greedily so balanced parentheses in cross-reference links
+# (``([*Foo*](bar))``) are preserved; the description separator is an en/em dash
+# (or hyphen) surrounded by whitespace.
+_PARAM_HEADER = re.compile(r"^\* \*\*Parameters:\*\*\s*$")
+_PARAM_ITEM = re.compile(r"^  \* \*\*(?P<name>.+?)\*\*(?P<rest>.*)$")
+_PARAM_DESC_SEP = re.compile(r"\s+[–—-]\s+")
+
+
+def _format_type_cell(raw: str) -> str:
+    """Render a parameter type for a table cell, keeping cross-reference links."""
+    cleaned = raw.replace("*", "").strip()
+    if not cleaned:
+        return ""
+    rendered: list[str] = []
+    for part in (p.strip() for p in cleaned.split("|")):
+        if not part:
+            continue
+        # Preserve markdown links / complex expressions verbatim; wrap plain
+        # type names in inline code.
+        if any(ch in part for ch in "[]()"):
+            rendered.append(part)
+        else:
+            rendered.append(f"`{part}`")
+    return " \\| ".join(rendered)
+
+
+def _escape_table_cell(text: str) -> str:
+    """Escape pipes so a description never breaks the surrounding table."""
+    return text.replace("|", "\\|").strip()
+
+
+def convert_parameter_lists_to_tables(content: str) -> str:
+    """Convert ``* **Parameters:**`` field lists into readable markdown tables.
+
+    The autodoc "Parameters" field list renders as a nested bullet list that is
+    hard to scan. This rewrites just the parameters block into a three-column
+    table (Parameter / Type / Description); sibling ``Raises``/``Returns`` field
+    lists are left untouched.
+    """
+    lines = content.split("\n")
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        if not _PARAM_HEADER.match(lines[i]):
+            out.append(lines[i])
+            i += 1
+            continue
+
+        # Collect the nested parameter items (and their wrapped continuation
+        # lines) until we dedent out of the block.
+        items: list[list[str]] = []  # [name, type, description]
+        j = i + 1
+        parsed_ok = True
+        while j < n:
+            item = _PARAM_ITEM.match(lines[j])
+            if item:
+                rest = item.group("rest").strip()
+                type_part, desc_part = "", ""
+                if rest.startswith("("):
+                    # Split "(type) – desc" on the first dash-separator.
+                    sep = _PARAM_DESC_SEP.search(rest)
+                    left = rest[: sep.start()] if sep else rest
+                    desc_part = rest[sep.end() :] if sep else ""
+                    type_part = left.strip().removeprefix("(").removesuffix(")")
+                items.append([item.group("name"), type_part, desc_part])
+                j += 1
+                continue
+            # Continuation line for the previous item (indented ≥ 4 spaces).
+            if lines[j].startswith("    ") and items:
+                items[-1][2] = (items[-1][2] + " " + lines[j].strip()).strip()
+                j += 1
+                continue
+            break
+
+        if not items:
+            parsed_ok = False
+        if not parsed_ok:
+            out.append(lines[i])
+            i += 1
+            continue
+
+        out.append("**Parameters:**")
+        out.append("")
+        out.append("| Parameter | Type | Description |")
+        out.append("| --- | --- | --- |")
+        for name, type_part, desc_part in items:
+            out.append(
+                f"| `{name}` | {_format_type_cell(type_part)} | "
+                f"{_escape_table_cell(desc_part)} |"
+            )
+        # Terminate the table with a blank line so a following field list
+        # (Raises/Returns) is not absorbed into the table block.
+        out.append("")
+        i = j
+    return "\n".join(out)
+
+
 def postprocess_markdown(content: str) -> str:
     """Apply all post-processing transformations to markdown content."""
 
@@ -214,6 +394,12 @@ def postprocess_markdown(content: str) -> str:
         content,
         flags=re.MULTILINE,
     )
+
+    # Keep multi-paragraph method descriptions inside their blockquote.
+    content = fix_description_blockquotes(content)
+
+    # Render the "Parameters" field lists as readable tables.
+    content = convert_parameter_lists_to_tables(content)
 
     # No longer need to escape <...> or {...} for MDX since we use
     # mdx.format: md in frontmatter (CommonMark mode).

--- a/scripts/postprocess_markdown.py
+++ b/scripts/postprocess_markdown.py
@@ -234,12 +234,15 @@ def fix_description_blockquotes(content: str) -> str:
             i += 1
 
         # Fold any blank-separated continuation paragraphs into the blockquote,
-        # up to the first structural boundary.
+        # up to the first structural boundary. A new blockquote (``> ...``) is
+        # itself a boundary: it is a separate blockquote, not a continuation,
+        # and treating it as one would loop forever (the inner loop below never
+        # consumes a line already starting with ``>``).
         while True:
             blank_start = i
             while i < n and lines[i].strip() == "":
                 i += 1
-            if i >= n or _BLOCKQUOTE_BOUNDARY.match(lines[i]):
+            if i >= n or lines[i].startswith(">") or _BLOCKQUOTE_BOUNDARY.match(lines[i]):
                 out.extend(lines[blank_start:i])
                 break
             # Separate paragraphs inside the blockquote with an empty quote line.

--- a/tests/acceptance/test_hook_flatten_client_docstring.py
+++ b/tests/acceptance/test_hook_flatten_client_docstring.py
@@ -1,0 +1,49 @@
+"""Tests for the flatten-client hook's docstring handling.
+
+The flattened client renames the generated ``body`` request parameter to
+``data`` in method signatures; the docstring must follow so the rendered API
+reference does not show a phantom ``body`` parameter alongside ``data``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_HOOK_DIR = Path(__file__).resolve().parents[2] / "hooks" / "post_gen"
+_HOOK = _HOOK_DIR / "0900_flatten_client.py"
+
+# The hook imports a sibling module (_identifier_guard); make it resolvable.
+if str(_HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOK_DIR))
+
+_spec = importlib.util.spec_from_file_location("flatten_client", _HOOK)
+assert _spec and _spec.loader
+_flatten = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_flatten)
+
+rename = _flatten._rename_body_arg_in_docstring
+
+
+class TestRenameBodyArgInDocstring:
+    def test_body_arg_renamed_to_data(self):
+        doc = "Restore from a backup\n\nArgs:\n    body (RestoreRequest): The request.\n\nReturns:\n    X\n"
+        result = rename(doc)
+        assert "    data (RestoreRequest): The request." in result
+        assert "    body (RestoreRequest)" not in result
+
+    def test_body_without_type_renamed(self):
+        doc = "Do it\n\nArgs:\n    body: The request.\n"
+        assert "    data: The request." in rename(doc)
+
+    def test_prose_mentioning_body_untouched(self):
+        doc = "Sends the request body to the server.\n\nArgs:\n    key (str): The key.\n"
+        result = rename(doc)
+        assert "Sends the request body to the server." in result
+
+    def test_body_outside_args_untouched(self):
+        doc = "Args:\n    key (str): The key.\n\nReturns:\n    body of the response.\n"
+        result = rename(doc)
+        assert "body of the response." in result
+
+    def test_none_docstring(self):
+        assert rename(None) is None

--- a/tests/acceptance/test_hook_flatten_client_docstring.py
+++ b/tests/acceptance/test_hook_flatten_client_docstring.py
@@ -12,14 +12,20 @@ from pathlib import Path
 _HOOK_DIR = Path(__file__).resolve().parents[2] / "hooks" / "post_gen"
 _HOOK = _HOOK_DIR / "0900_flatten_client.py"
 
-# The hook imports a sibling module (_identifier_guard); make it resolvable.
-if str(_HOOK_DIR) not in sys.path:
+# The hook imports a sibling module (_identifier_guard); make it resolvable
+# only while loading, then restore sys.path so the mutation does not leak into
+# other tests running in the same process.
+_added_to_path = str(_HOOK_DIR) not in sys.path
+if _added_to_path:
     sys.path.insert(0, str(_HOOK_DIR))
-
-_spec = importlib.util.spec_from_file_location("flatten_client", _HOOK)
-assert _spec and _spec.loader
-_flatten = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_flatten)
+try:
+    _spec = importlib.util.spec_from_file_location("flatten_client", _HOOK)
+    assert _spec and _spec.loader
+    _flatten = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_flatten)
+finally:
+    if _added_to_path:
+        sys.path.remove(str(_HOOK_DIR))
 
 rename = _flatten._rename_body_arg_in_docstring
 

--- a/tests/acceptance/test_postprocess_markdown.py
+++ b/tests/acceptance/test_postprocess_markdown.py
@@ -1,0 +1,138 @@
+"""Tests for the markdown post-processing that renders the API reference.
+
+These guard the class of rendering defects reported on the generated docs:
+
+* keyword-only ``*`` separators dropped from method signatures, leaving an
+  empty comma slot (``restore(, data, **kwargs)``);
+* multi-paragraph method descriptions escaping their blockquote;
+* the "Parameters" field list rendering as a hard-to-scan nested bullet list.
+
+They import the post-processing module directly (no Sphinx build required).
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "postprocess_markdown.py"
+_spec = importlib.util.spec_from_file_location("postprocess_markdown", _SCRIPT)
+assert _spec and _spec.loader
+postprocess_markdown = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(postprocess_markdown)
+
+_restore_keyword_only_marker = postprocess_markdown._restore_keyword_only_marker
+fix_description_blockquotes = postprocess_markdown.fix_description_blockquotes
+convert_parameter_lists_to_tables = postprocess_markdown.convert_parameter_lists_to_tables
+run = postprocess_markdown.postprocess_markdown
+
+
+class TestKeywordOnlyMarker:
+    """The dropped ``*`` keyword-only separator must be restored."""
+
+    def test_leading_dropped_marker_restored(self):
+        assert _restore_keyword_only_marker(", data, **kwargs") == "*, data, **kwargs"
+
+    def test_middle_dropped_marker_restored(self):
+        assert (
+            _restore_keyword_only_marker("tenant_id, , data, **kwargs")
+            == "tenant_id, *, data, **kwargs"
+        )
+
+    def test_empty_parameter_list_untouched(self):
+        assert _restore_keyword_only_marker("") == ""
+
+    def test_existing_marker_preserved(self):
+        assert (
+            _restore_keyword_only_marker("*, mode, dry_run=<Unset>, **kwargs")
+            == "*, mode, dry_run=<Unset>, **kwargs"
+        )
+
+    def test_no_empty_comma_slot_survives_full_pipeline(self):
+        source = "#### *async* restore(, data, \\*\\*kwargs)\n"
+        result = run(source)
+        assert "def restore(*, data, **kwargs)" in result
+        assert "(, data" not in result
+        assert ", ," not in result
+
+    def test_no_arg_method_stays_empty(self):
+        result = run("#### run_workers()\n")
+        assert "def run_workers()" in result
+        assert "(*)" not in result
+
+    def test_path_parameter_method(self):
+        result = run("#### *async* update_tenant(tenant_id, , data, \\*\\*kwargs)\n")
+        assert "def update_tenant(tenant_id, *, data, **kwargs)" in result
+
+
+class TestDescriptionBlockquotes:
+    """Continuation paragraphs fold back into the method-description blockquote."""
+
+    def test_continuation_paragraph_folded(self):
+        source = (
+            "> Restores the cluster from a backup. It is described either by a\n"
+            "\n"
+            "time range that selects the backups to restore. This endpoint is only\n"
+            "accessible while the cluster is in recovery mode.\n"
+            "\n"
+            "* **Parameters:**\n"
+            "  * **data** (*RestoreRequest*)\n"
+        )
+        result = fix_description_blockquotes(source)
+        assert "> time range that selects the backups to restore." in result
+        assert "> accessible while the cluster is in recovery mode." in result
+        # No flush-left continuation line escapes the blockquote.
+        assert "\ntime range that selects" not in result
+
+    def test_stops_at_boundary(self):
+        source = "> Summary line.\n\n* **Parameters:**\n  * **data** (*X*)\n"
+        result = fix_description_blockquotes(source)
+        assert result == source
+
+    def test_non_blockquote_content_untouched(self):
+        source = "Close the client.\n\nThis closes both clients.\n\n* **Return type:**\n  None\n"
+        assert fix_description_blockquotes(source) == source
+
+
+class TestParameterTables:
+    """The Parameters field list renders as a markdown table."""
+
+    def test_parameters_become_table(self):
+        source = (
+            "* **Parameters:**\n"
+            "  * **data** (*RestoreRequest*) – Describes a restore request. Provide either a\n"
+            "    list of backup IDs or a time range.\n"
+            "  * **kwargs** (*Any*)\n"
+            "* **Raises:**\n"
+            "  * **errors.BadRequestError** – If the response status code is 400.\n"
+        )
+        result = convert_parameter_lists_to_tables(source)
+        assert "| Parameter | Type | Description |" in result
+        assert "| --- | --- | --- |" in result
+        assert "| `data` | `RestoreRequest` |" in result
+        assert "list of backup IDs or a time range." in result
+        assert "| `kwargs` | `Any` |  |" in result
+        # The nested bullet form is gone for parameters ...
+        assert "  * **data**" not in result
+        # ... but sibling field lists (Raises) are left untouched.
+        assert "* **Raises:**" in result
+        assert "  * **errors.BadRequestError**" in result
+        # The table is terminated by a blank line before the Raises field list.
+        assert "|\n\n* **Raises:**" in result
+
+    def test_link_type_preserved(self):
+        source = (
+            "* **Parameters:**\n"
+            "  * **configuration** ([*CamundaSdkConfiguration*](runtime.md#cfg))\n"
+        )
+        result = convert_parameter_lists_to_tables(source)
+        assert "[CamundaSdkConfiguration](runtime.md#cfg)" in result
+        assert "| `configuration` |" in result
+
+    def test_union_type_rendered(self):
+        source = "* **Parameters:**\n  * **name** (*str* *|* *None*) – The name.\n"
+        result = convert_parameter_lists_to_tables(source)
+        assert "`str` \\| `None`" in result
+
+    def test_pipe_in_description_escaped(self):
+        source = "* **Parameters:**\n  * **name** (*str*) – Either a | b.\n"
+        result = convert_parameter_lists_to_tables(source)
+        assert "Either a \\| b." in result

--- a/tests/acceptance/test_postprocess_markdown.py
+++ b/tests/acceptance/test_postprocess_markdown.py
@@ -91,6 +91,14 @@ class TestDescriptionBlockquotes:
         source = "Close the client.\n\nThis closes both clients.\n\n* **Return type:**\n  None\n"
         assert fix_description_blockquotes(source) == source
 
+    def test_blockquote_followed_by_blockquote_terminates(self):
+        # A blockquote followed (after blank lines) by another blockquote must
+        # not hang: the second ``>`` is a separate blockquote, not a
+        # continuation paragraph, so both are preserved verbatim.
+        source = "> First blockquote.\n\n> Second blockquote.\n"
+        result = fix_description_blockquotes(source)
+        assert result == source
+
 
 class TestParameterTables:
     """The Parameters field list renders as a markdown table."""


### PR DESCRIPTION
## What

Fixes rendering defects reported on the generated Python API reference (camunda/camunda-docs#9407), all in the markdown post-processing / doc generation:

1. **Broken signatures** — `sphinx-markdown-builder` drops the keyword-only `*` marker, leaving an empty comma slot (`restore(, data, **kwargs)`). Restored to `restore(*, data, **kwargs)`.
2. **Description text escaping its blockquote** — continuation paragraphs are folded back into the preceding blockquote.
3. **Parameter field lists** — converted to proper markdown tables.
4. **`body` vs `data` mismatch** — the generated docstring `Args:` entry is renamed `body` -> `data` so the Parameters table matches the signature.
5. **`from_/to` wording** — corrected to `from/to` in the restore example.

## How

- `scripts/postprocess_markdown.py`: `_restore_keyword_only_marker`, `fix_description_blockquotes`, `convert_parameter_lists_to_tables` (wired into the pipeline).
- `hooks/post_gen/0900_flatten_client.py`: `_rename_body_arg_in_docstring` applied at both sync and async docstring emission.
- `examples/admin_operations.py`: `from_/to` -> `from/to`.
- Acceptance tests: `tests/acceptance/test_postprocess_markdown.py` and `test_hook_flatten_client_docstring.py`.

Generated output is intentionally **not** committed — CI regenerates it on this branch.