### PR TITLE
docs: add examples for process instance suspend/resume/business-id operations

### DIFF
--- a/examples/batch_operation.py
+++ b/examples/batch_operation.py
@@ -23,6 +23,8 @@ from camunda_orchestration_sdk import (
     ProcessInstanceMigrationBatchOperationRequestMigrationPlan,
     ProcessInstanceModificationBatchOperationRequest,
     ProcessInstanceModificationMoveBatchOperationInstruction,
+    ProcessInstanceResumptionBatchOperationRequest,
+    ProcessInstanceSuspensionBatchOperationRequest,
     Unset,
 )
 
@@ -214,3 +216,31 @@ def update_jobs_batch_operation_example() -> None:
 
     print(f"Batch operation key: {result.batch_operation_key}")
 # endregion UpdateJobsBatchOperation
+
+
+# region SuspendProcessInstancesBatchOperation
+def suspend_process_instances_batch_operation_example() -> None:
+    client = CamundaClient()
+
+    result = client.suspend_process_instances_batch_operation(
+        data=ProcessInstanceSuspensionBatchOperationRequest(
+            filter_=ProcessInstanceCancellationBatchOperationRequestFilter(),
+        ),
+    )
+
+    print(f"Batch operation key: {result.batch_operation_key}")
+# endregion SuspendProcessInstancesBatchOperation
+
+
+# region ResumeProcessInstancesBatchOperation
+def resume_process_instances_batch_operation_example() -> None:
+    client = CamundaClient()
+
+    result = client.resume_process_instances_batch_operation(
+        data=ProcessInstanceResumptionBatchOperationRequest(
+            filter_=ProcessInstanceCancellationBatchOperationRequestFilter(),
+        ),
+    )
+
+    print(f"Batch operation key: {result.batch_operation_key}")
+# endregion ResumeProcessInstancesBatchOperation

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -119,6 +119,27 @@
             "label": "Search process instances"
         }
     ],
+    "suspend_process_instance": [
+        {
+            "file": "process_instance.py",
+            "region": "SuspendProcessInstance",
+            "label": "Suspend a process instance"
+        }
+    ],
+    "resume_process_instance": [
+        {
+            "file": "process_instance.py",
+            "region": "ResumeProcessInstance",
+            "label": "Resume a process instance"
+        }
+    ],
+    "assign_process_instance_business_id": [
+        {
+            "file": "process_instance.py",
+            "region": "AssignProcessInstanceBusinessId",
+            "label": "Assign a business id to a process instance"
+        }
+    ],
     "activate_jobs": [
         {
             "file": "job.py",
@@ -816,6 +837,20 @@
             "file": "batch_operation.py",
             "region": "UpdateJobsBatchOperation",
             "label": "Update jobs in batch"
+        }
+    ],
+    "suspend_process_instances_batch_operation": [
+        {
+            "file": "batch_operation.py",
+            "region": "SuspendProcessInstancesBatchOperation",
+            "label": "Suspend process instances in batch"
+        }
+    ],
+    "resume_process_instances_batch_operation": [
+        {
+            "file": "batch_operation.py",
+            "region": "ResumeProcessInstancesBatchOperation",
+            "label": "Resume process instances in batch"
         }
     ],
     "delete_process_instance": [

--- a/examples/process_instance.py
+++ b/examples/process_instance.py
@@ -9,6 +9,8 @@ from camunda_orchestration_sdk import (
     ProcessCreationByKey,
     ProcessDefinitionId,
     ProcessDefinitionKey,
+    ProcessInstanceBusinessIdAssignmentInstruction,
+    ProcessInstanceKey,
     ProcessInstanceSearchQuery,
     ProcessInstanceSearchQueryFilter,
     ProcessInstanceSearchQuerySortRequest,
@@ -106,3 +108,36 @@ def search_process_instances_example() -> None:
         print(f"{instance.process_instance_key}: {instance.state}")
     print(f"Total: {result.page.total_items}")
 # endregion SearchProcessInstances
+
+
+# region SuspendProcessInstance
+def suspend_process_instance_example(process_instance_key: ProcessInstanceKey) -> None:
+    client = CamundaClient()
+
+    client.suspend_process_instance(
+        process_instance_key=process_instance_key,
+    )
+# endregion SuspendProcessInstance
+
+
+# region ResumeProcessInstance
+def resume_process_instance_example(process_instance_key: ProcessInstanceKey) -> None:
+    client = CamundaClient()
+
+    client.resume_process_instance(
+        process_instance_key=process_instance_key,
+    )
+# endregion ResumeProcessInstance
+
+
+# region AssignProcessInstanceBusinessId
+def assign_process_instance_business_id_example(process_instance_key: ProcessInstanceKey) -> None:
+    client = CamundaClient()
+
+    client.assign_process_instance_business_id(
+        process_instance_key=process_instance_key,
+        data=ProcessInstanceBusinessIdAssignmentInstruction(
+            business_id="order-12345",
+        ),
+    )
+# endregion AssignProcessInstanceBusinessId


### PR DESCRIPTION
## Description

Adds compilable usage examples and `operation-map.json` entries for the 5 process instance operations added in 8.10, bringing example coverage to 100% (203/203).

| Operation | File | Region |
|---|---|---|
| `suspend_process_instance` | `examples/process_instance.py` | SuspendProcessInstance |
| `resume_process_instance` | `examples/process_instance.py` | ResumeProcessInstance |
| `assign_process_instance_business_id` | `examples/process_instance.py` | AssignProcessInstanceBusinessId |
| `suspend_process_instances_batch_operation` | `examples/batch_operation.py` | SuspendProcessInstancesBatchOperation |
| `resume_process_instances_batch_operation` | `examples/batch_operation.py` | ResumeProcessInstancesBatchOperation |

Per the example-coverage convention, only the example files are committed; the SDK was regenerated locally for type-checking and the generated drift discarded.

## Validation

- `ty check examples/` — passed
- `scripts/check_example_coverage.py` — 100% (203/203)
- `ruff check` on both edited files — clean
- `pytest tests/acceptance` — 509 passed, 1 skipped

Closes #201