### PR TITLE
docs: fix Parameters header and split-sentence rendering in blockquotes

### DIFF
--- a/scripts/postprocess_markdown.py
+++ b/scripts/postprocess_markdown.py
@@ -243,10 +243,22 @@ def fix_description_blockquotes(content: str) -> str:
             while i < n and lines[i].strip() == "":
                 i += 1
             if i >= n or lines[i].startswith(">") or _BLOCKQUOTE_BOUNDARY.match(lines[i]):
+                # A structural boundary that directly abuts the blockquote (no
+                # blank line between) must be separated by one, or CommonMark
+                # lazy continuation folds it into the quote paragraph (e.g. the
+                # "Parameters:" header rendering *inside* the blockquote).
+                if blank_start == i and i < n and not lines[i].startswith(">"):
+                    out.append("")
                 out.extend(lines[blank_start:i])
                 break
-            # Separate paragraphs inside the blockquote with an empty quote line.
-            out.append(">")
+            # Fold the continuation paragraph into the blockquote. Only start a
+            # new paragraph (empty ``>`` separator) when the preceding quoted
+            # line ends a sentence; a line lacking terminal punctuation is a
+            # hard-wrap of the same sentence and must stay in one paragraph
+            # (otherwise a single sentence renders as multiple paragraphs).
+            prev_text = out[-1].lstrip(">").strip() if out else ""
+            if prev_text and prev_text[-1] in ".!?:":
+                out.append(">")
             while (
                 i < n
                 and lines[i].strip() != ""

--- a/tests/acceptance/test_postprocess_markdown.py
+++ b/tests/acceptance/test_postprocess_markdown.py
@@ -99,6 +99,71 @@ class TestDescriptionBlockquotes:
         result = fix_description_blockquotes(source)
         assert result == source
 
+    def test_blockquote_abutting_field_list_gets_blank_separator(self):
+        # A description blockquote *immediately* followed (no blank line) by a
+        # field-list boundary must be separated by a blank line. Otherwise
+        # CommonMark lazy continuation absorbs the boundary into the quote,
+        # rendering e.g. the "Parameters:" header *inside* the blockquote.
+        source = (
+            "> Search for decision instances based on given criteria.\n"
+            "* **Parameters:**\n"
+            "  * **body** (*X*)\n"
+        )
+        result = fix_description_blockquotes(source)
+        assert (
+            "> Search for decision instances based on given criteria.\n"
+            "\n"
+            "* **Parameters:**" in result
+        )
+
+    def test_blockquote_abutting_boundary_gets_blank_separator(self):
+        # Class-scoped guard: *any* non-blockquote structural boundary that
+        # directly abuts a blockquote (no blank line) must be separated, not
+        # just the Parameters field list.
+        source = "> Summary with no trailing blank.\n### Heading\n"
+        result = fix_description_blockquotes(source)
+        assert "> Summary with no trailing blank.\n\n### Heading" in result
+
+    def test_hardwrap_continuation_stays_one_paragraph(self):
+        # A continuation line whose preceding quoted line does not end in
+        # sentence-terminating punctuation is a hard-wrap of the same
+        # sentence. Folding it must NOT insert an empty ``>`` separator, which
+        # would render as two paragraphs for a single sentence.
+        source = (
+            "> Search for incidents caused by the specified element instance, "
+            "including incidents of any child\n"
+            "\n"
+            "instances created from this element instance.\n"
+            "\n"
+            "* **Parameters:**\n"
+            "  * **body** (*X*)\n"
+        )
+        result = fix_description_blockquotes(source)
+        assert (
+            "> Search for incidents caused by the specified element instance, "
+            "including incidents of any child\n"
+            "> instances created from this element instance." in result
+        )
+        # No empty ``>`` separator splits the single sentence.
+        assert ">\n> instances created" not in result
+
+    def test_sentence_boundary_keeps_separate_paragraph(self):
+        # A continuation whose preceding quoted line ends in terminal
+        # punctuation is a genuinely new paragraph and must remain separated by
+        # an empty ``>`` line inside the blockquote.
+        source = (
+            "> First complete sentence.\n"
+            "\n"
+            "Second distinct paragraph here.\n"
+            "\n"
+            "* **Parameters:**\n"
+            "  * **body** (*X*)\n"
+        )
+        result = fix_description_blockquotes(source)
+        assert (
+            "> First complete sentence.\n>\n> Second distinct paragraph here." in result
+        )
+
 
 class TestParameterTables:
     """The Parameters field list renders as a markdown table."""


### PR DESCRIPTION
## Summary

Follow-up to #209. Fixes two rendering defects in the auto-generated Python **async-client** API reference, both traced to `fix_description_blockquotes` in `scripts/postprocess_markdown.py`. No SDK regeneration — post-processor only.

### 1. `Parameters:` header rendered *inside* the description blockquote

`sphinx-markdown-builder` emitted the `* **Parameters:**` field list directly after the description blockquote with **no blank line** between them. After the table conversion, `**Parameters:**` sat on the line immediately below the `>` quote, so CommonMark **lazy continuation** folded the header into the blockquote paragraph:

```html
<blockquote><p>Search for decision instances based on given criteria. <strong>Parameters:</strong></p></blockquote>
```

**Fix:** insert a blank line whenever a non-blockquote structural boundary directly abuts a blockquote, terminating the quote so the boundary renders on its own. (e.g. `search_decision_instances`)

### 2. A single sentence split into multiple paragraphs

The fold loop unconditionally inserted an empty `>` separator before every continuation paragraph, so a hard-wrapped sentence rendered as two paragraphs:

> Search for incidents caused by the specified element instance, including incidents of any child
>
> instances created from this element instance.

**Fix:** only start a new blockquote paragraph when the preceding quoted line ends in terminal punctuation (`.!?:`); a line lacking it is a hard-wrap of the same sentence and stays in one paragraph. (e.g. `search_element_instance_incidents`)

## Testing

- Added 4 class-scoped tests to `tests/acceptance/test_postprocess_markdown.py` (red → green); the 3 behaviour-changing ones failed against the old code and now pass.
- Full module: **19 passed**; `ruff` clean.
- Verified against a fresh Sphinx build + post-processor run: the Parameters header now sits below the blockquote (blank-line separated), and the incident-search sentence renders as one paragraph while the following "Although…" paragraph stays separate.
