### PR TITLE
docs: add resolve_secrets example and operation-map entry

### DIFF
--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1440,5 +1440,12 @@
             "region": "GetGlobalJobStatistics",
             "label": "Get global job statistics"
         }
+    ],
+    "resolve_secrets": [
+        {
+            "file": "secret.py",
+            "region": "ResolveSecrets",
+            "label": "Resolve secrets"
+        }
     ]
 }

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -11,6 +11,10 @@ from camunda_orchestration_sdk import (
 def resolve_secrets_example() -> None:
     client = CamundaClient()
 
+    # Hands the resolved secret to whatever needs it (an HTTP client, a DB
+    # driver, ...) without logging it.
+    def use_secret(value: str) -> None: ...
+
     result = client.resolve_secrets(
         data=SecretResolveRequest(
             references=[
@@ -23,7 +27,7 @@ def resolve_secrets_example() -> None:
     # Successfully resolved references are returned in `resolved`; references that
     # could not be resolved are returned in `errors`, each with a typed error code.
     # Never log a resolved value -- it holds secret material. Pass it straight to
-    # the consumer that needs it (HTTP client, DB driver, ...) instead.
+    # the consumer that needs it instead.
     for resolved in result.resolved:
         print(f"Resolved {resolved.reference} (value redacted)")
         use_secret(resolved.value)
@@ -31,8 +35,3 @@ def resolve_secrets_example() -> None:
     for error in result.errors:
         print(f"Failed to resolve {error.reference}: {error.code.value} - {error.message}")
 # endregion ResolveSecrets
-
-
-# Hands the resolved secret to whatever needs it, without logging it.
-def use_secret(value: str) -> None:
-    pass

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -1,0 +1,38 @@
+# Compilable usage examples for secret operations.
+# These examples are type-checked during build to guard against API regressions.
+from __future__ import annotations
+
+from camunda_orchestration_sdk import (
+    CamundaClient,
+    SecretResolveRequest,
+)
+
+# region ResolveSecrets
+def resolve_secrets_example() -> None:
+    client = CamundaClient()
+
+    result = client.resolve_secrets(
+        data=SecretResolveRequest(
+            references=[
+                "camunda.secrets.my_api_token",
+                "camunda.secrets.db_password",
+            ],
+        )
+    )
+
+    # Successfully resolved references are returned in `resolved`; references that
+    # could not be resolved are returned in `errors`, each with a typed error code.
+    # Never log a resolved value -- it holds secret material. Pass it straight to
+    # the consumer that needs it (HTTP client, DB driver, ...) instead.
+    for resolved in result.resolved:
+        print(f"Resolved {resolved.reference} (value redacted)")
+        use_secret(resolved.value)
+
+    for error in result.errors:
+        print(f"Failed to resolve {error.reference}: {error.code.value} - {error.message}")
+# endregion ResolveSecrets
+
+
+# Hands the resolved secret to whatever needs it, without logging it.
+def use_secret(value: str) -> None:
+    pass


### PR DESCRIPTION
## Description

Adds SDK example coverage for the new `resolveSecrets` operation (`POST /secrets/resolve`, added in 8.10), closing the last remaining example-coverage gap flagged by the daily new-operations check.

Closes #214

### What's in here

Following the convention of recent example-coverage PRs (`change_cluster_mode`, `restore`, `search_process_definition_variable_names`, suspend/resume), this PR touches **only** `examples/*`:

- `examples/secret.py` — a compilable, region-tagged (`# region ResolveSecrets`) example.
- `examples/operation-map.json` — maps `resolve_secrets` -> the new example region.

No ergonomic helper exists for this operation, so the map points at the generated method directly.

No regenerated output is committed. CI's `make generate` regenerates `generated/` + `stubs/` fresh from the latest upstream spec (which contains `resolve_secrets`), type-checks the example against it, and validates coverage. The committed `generated/` snapshot is caught up separately by periodic re-bundle / release PRs.

### Security note

The example never logs a resolved secret value — it prints only the (non-sensitive) reference and hands the value straight to a consumer stub. This mirrors the redaction applied to the equivalent C# example ([csharp#347](https://github.com/camunda/orchestration-cluster-api-csharp/pull/347)) after review feedback: examples get copied verbatim, so they must model safe handling.

### Validation

Verified locally against a freshly bundled + regenerated SDK:

- `ruff check examples/secret.py` — clean
- `ty check examples/` — clean
- `scripts/check_example_coverage.py` — 100% (204/204), all regions resolve
