### PR TITLE
refactor: enable maximum ty strictness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,42 @@ exclude = [
 ]
 
 [tool.ty.rules]
-# Project still emits some patterns where ty's inference is stricter than pyright's
-# was; tune these down where appropriate after the initial migration.
+# Maximum strictness: every ty rule is treated as an error. The 93 rules that already
+# default to "error" need no entry here; the block below escalates the 21 "warn"-default
+# and 5 "ignore"-default rules to "error" so no type-safety signal is silently downgraded.
+# Verified green against the current tree with `ty check --error all`. If a future change
+# cannot satisfy one of these, downgrade that single rule here with an inline justification
+# rather than relaxing the whole set.
+
+# Escalated from the "warn" default level.
+ambiguous-protocol-member = "error"
+deprecated = "error"
+ignore-comment-unknown-rule = "error"
+ineffective-final = "error"
+invalid-enum-member-annotation = "error"
+invalid-ignore-comment = "error"
+invalid-legacy-positional-parameter = "error"
+invalid-named-tuple-override = "error"
+mismatched-type-name = "error"
+possibly-missing-implicit-call = "error"
+possibly-missing-submodule = "error"
+redundant-cast = "error"
+redundant-final-classvar = "error"
+subclass-of-dataclass-with-order = "error"
+undefined-reveal = "error"
+unresolved-global = "error"
+unsupported-base = "error"
+unused-awaitable = "error"
+unused-ignore-comment = "error"
+unused-type-ignore-comment = "error"
+useless-overload-body = "error"
+
+# Escalated from the "ignore" (disabled) default level.
+division-by-zero = "error"
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+possibly-unresolved-reference = "error"
+unsupported-dynamic-base = "error"
 
 [tool.ruff]
 extend-exclude = [


### PR DESCRIPTION
Closes #203. Part of the PLE audit (#202).

## What
Turns `[tool.ty.rules]` from an empty placeholder (with a "tune these down after migration" TODO) into an explicit **maximum-strictness** configuration: every ty rule is treated as an error.

ty 0.0.40 ships 119 rules — 93 default to `error`, 21 to `warn`, 5 to `ignore` (disabled). This change escalates all 26 non-`error` rules to `error`, so no type-safety signal is silently downgraded. The 93 already-`error` rules need no entry.

## Verification
- `ty check --error all` → `All checks passed!` (the whole rule set is satisfiable against the current tree).
- `ty check` with the new config-driven rules → `All checks passed!`, exit 0.

No code changes were required — the tree was already clean at maximum severity.

## Notes
- The 5 previously-disabled rules (`division-by-zero`, `possibly-missing-attribute`, `possibly-missing-import`, `possibly-unresolved-reference`, `unsupported-dynamic-base`) are now enforced.
- If a future change genuinely cannot satisfy one rule, downgrade that single rule inline with a justification rather than relaxing the whole set (documented in the config comment).

## Acceptance criteria
- [x] `[tool.ty.rules]` configured for the strictest viable set.
- [x] "tune down after migration" TODO removed.
- [x] `ty check` passes.

Config-only change; no generated output touched.
