### PR TITLE
refactor: expand ruff rule selection and error on warnings (#207)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -85,7 +85,7 @@ def load_hooks(hooks_dir: Path) -> list[Callable[[dict[str, str]], None]]:
         if spec and spec.loader:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-            if hasattr(module, "run") and callable(getattr(module, "run")):
+            if hasattr(module, "run") and callable(module.run):
                 hooks.append(module.run)
     return hooks
 
@@ -104,7 +104,7 @@ def run_acceptance_tests(root: Path, out_dir: Path) -> None:
     existing = env.get("PYTHONPATH", "")
     # Ensure generated code is importable by tests
     env["PYTHONPATH"] = (
-        f"{str(out_dir)}{os.pathsep}{existing}" if existing else str(out_dir)
+        f"{out_dir!s}{os.pathsep}{existing}" if existing else str(out_dir)
     )
     tests_dir = root / "tests" / "acceptance"
     cmd = [sys.executable, "-m", "pytest", "-q", str(tests_dir)]

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -722,7 +722,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
 
                 new_kwonlyargs: list[ast.arg] = []
                 new_kw_defaults: list[ast.expr | None] = []
-                for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+                for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False):
                     if arg.arg != "client":
                         new_kwonlyargs.append(arg)
                         new_kw_defaults.append(default)
@@ -743,7 +743,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                 elif new_kwonlyargs:
                     arg_strs.append("*")
 
-                for arg, default in zip(new_kwonlyargs, new_kw_defaults):
+                for arg, default in zip(new_kwonlyargs, new_kw_defaults, strict=False):
                     arg_name = "data" if arg.arg == "body" else arg.arg
                     ann = f": {ast.unparse(arg.annotation)}" if arg.annotation else ""
                     default_str = f" = {ast.unparse(default)}" if default else ""
@@ -884,7 +884,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
 
                 new_kwonlyargs: list[ast.arg] = []
                 new_kw_defaults: list[ast.expr | None] = []
-                for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+                for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=False):
                     if arg.arg != "client":
                         new_kwonlyargs.append(arg)
                         new_kw_defaults.append(default)
@@ -905,7 +905,7 @@ def generate_flat_client(package_path: Path, spec_path: Path | None = None, meta
                 elif new_kwonlyargs:
                     arg_strs.append("*")
 
-                for arg, default in zip(new_kwonlyargs, new_kw_defaults):
+                for arg, default in zip(new_kwonlyargs, new_kw_defaults, strict=False):
                     arg_name = "data" if arg.arg == "body" else arg.arg
                     ann = f": {ast.unparse(arg.annotation)}" if arg.annotation else ""
                     default_str = f" = {ast.unparse(default)}" if default else ""

--- a/hooks/post_gen/0900_flatten_client.py
+++ b/hooks/post_gen/0900_flatten_client.py
@@ -1270,7 +1270,7 @@ class CamundaClient:
             try:
                 self.client.get_httpx_client().close()
             except Exception:
-                return
+                pass
 
     def deploy_resources_from_files(self, files: list[str | Path], tenant_id: str | None = None) -> ExtendedDeploymentResult:
         """Deploy BPMN/DMN/Form resources from local files.

--- a/hooks/post_gen/1000_patch_semantic_types_in_models.py
+++ b/hooks/post_gen/1000_patch_semantic_types_in_models.py
@@ -145,13 +145,17 @@ def _patch_model_file(file_path: Path, semantic_mappings: Dict[str, str], union_
             re.MULTILINE,
         )
 
-        def type_hint_replacer(match: re.Match[str]) -> str:
+        def type_hint_replacer(
+            match: re.Match[str],
+            _py_prop: str = py_prop,
+            _semantic_type: str = semantic_type,
+        ) -> str:
             indent = match.group(1)
             old_type = match.group(2)
             rest = match.group(3)
             if old_type.startswith("None | "):
-                return f"{indent}{py_prop}: None | {semantic_type}{rest}"
-            return f"{indent}{py_prop}: {semantic_type}{rest}"
+                return f"{indent}{_py_prop}: None | {_semantic_type}{rest}"
+            return f"{indent}{_py_prop}: {_semantic_type}{rest}"
 
         content = type_hint_pattern.sub(type_hint_replacer, content)
 
@@ -162,7 +166,9 @@ def _patch_model_file(file_path: Path, semantic_mappings: Dict[str, str], union_
         # Note: json_prop in the regex needs to be escaped if it contains special chars, but usually it doesn't.
         pop_pattern = re.compile(rf'(\s+){py_prop} = (d\.pop\("{json_prop}"[^)]*\))')
 
-        def pop_replacer(match: re.Match[str], _ctor: str = constructor) -> str:
+        def pop_replacer(
+            match: re.Match[str], _ctor: str = constructor, _py_prop: str = py_prop
+        ) -> str:
             indent = match.group(1)
             pop_call = match.group(2)
 
@@ -173,9 +179,9 @@ def _patch_model_file(file_path: Path, semantic_mappings: Dict[str, str], union_
             if default_match:
                 default_val = default_match.group(1)
                 # Use walrus operator to capture value and check against default
-                return f"{indent}{py_prop} = {_ctor}(_val) if (_val := {pop_call}) is not {default_val} else {default_val}"
+                return f"{indent}{_py_prop} = {_ctor}(_val) if (_val := {pop_call}) is not {default_val} else {default_val}"
 
-            return f"{indent}{py_prop} = {_ctor}({pop_call})"
+            return f"{indent}{_py_prop} = {_ctor}({pop_call})"
 
         # Check if already patched to avoid double patching
         if (

--- a/hooks/pre_gen/0100_patch_bundled_spec.py
+++ b/hooks/pre_gen/0100_patch_bundled_spec.py
@@ -303,11 +303,9 @@ class SpecFlattener:
                 # If we have a oneOf, removing the explicit type: object allows the union to work
                 # even if some options are primitives (like string vs object filter)
                 if "oneOf" in new_schema:
-                    if "type" in new_schema:
-                        del new_schema["type"]
+                    new_schema.pop("type", None)
                     # Also remove description as it might confuse the generator into making a class
-                    if "description" in new_schema:
-                        del new_schema["description"]
+                    new_schema.pop("description", None)
 
             else:
                 # Fallback: keep allOf if we don't know how to merge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# Generated code is excluded from normal lint via `extend-exclude`, but the generation step
+# runs `ruff check generated/ --fix` with an explicit path (which bypasses excludes) to clean
+# up imports and formatting. The expanded families (B/RUF/ASYNC/S) are meaningless on
+# machine-generated output and largely non-fixable, so scope that pass down to the base rules.
+"generated/**" = ["B", "RUF", "ASYNC", "S"]
+"stubs/**" = ["B", "RUF", "ASYNC", "S"]
 # Bandit (S) targets production code paths handling untrusted input. Asserts (S101) are the
 # idiomatic test assertion, and any hardcoded credentials / subprocess usage in the suite are
 # test fixtures, not security-relevant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,49 @@ exclude = [
 [tool.ruff]
 extend-exclude = [
     "generated",
+    "stubs",
+]
+
+[tool.ruff.lint]
+# Ruff's default rules (E4/E7/E9, F) plus additional families:
+#   B      flake8-bugbear   — likely bugs (loop-variable capture, missing zip strict, …)
+#   RUF    Ruff-specific    — mutable defaults, unsorted __all__, unused noqa, …
+#   ASYNC  flake8-async     — blocking calls inside async functions
+#   S      flake8-bandit    — security scanning of production code paths
+extend-select = ["B", "RUF", "ASYNC", "S"]
+ignore = [
+    # Ambiguous-unicode checks fire on intentional typographic characters (em dashes,
+    # arrows, non-breaking spaces) in strings/docstrings/comments. Rewriting them adds no
+    # value and hurts readability.
+    "RUF001",
+    "RUF002",
+    "RUF003",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Bandit (S) targets production code paths handling untrusted input. Asserts (S101) are the
+# idiomatic test assertion, and any hardcoded credentials / subprocess usage in the suite are
+# test fixtures, not security-relevant.
+"tests/**" = ["S"]
+# Examples deliberately show fake credentials for illustration.
+"examples/**" = ["S"]
+# Build/generation tooling runs locally against developer-controlled, trusted inputs (the git
+# checkout, the bundled spec). Its subprocess calls (git/uv/npx), md5 cache keys, asserts, and
+# SQL-like strings embedded in generated-code templates are intentional and not attack surface.
+"generate.py" = ["S"]
+"bundle.py" = ["S"]
+"hooks/**" = ["S"]
+"scripts/**" = ["S"]
+
+[tool.pytest.ini_options]
+# Treat warnings as errors so that deprecations and resource-leak warnings surface as test
+# failures instead of being silently ignored.
+filterwarnings = [
+    "error",
+    # Unraisable exceptions (e.g. ResourceWarning from an event loop or socket collected during
+    # GC) are surfaced non-deterministically by the interpreter, not emitted synchronously by the
+    # code under test, so they cannot be reliably asserted on and are treated as noise here.
+    "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 
 [build-system]

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -42,6 +42,7 @@ from .typed_variables import (
 )
 
 __all__ = [
+    "EXEMPT_METHODS",
     "AsyncAuthProvider",
     "AsyncBackpressureManager",
     "AsyncOAuthClientCredentialsAuthProvider",
@@ -52,7 +53,6 @@ __all__ = [
     "BasicAuthProvider",
     "CamundaLogger",
     "ConsistencyOptions",
-    "EXEMPT_METHODS",
     "EventualConsistencyTimeoutError",
     "NullAuthProvider",
     "NullLogger",

--- a/runtime/auth.py
+++ b/runtime/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import hashlib
 import json
 import os
@@ -275,10 +276,8 @@ class OAuthClientCredentialsAuthProvider:
                 access_token=str(access_token), expires_at_epoch_s=float(expires_at)
             )
             if not self._is_valid(token):
-                try:
+                with contextlib.suppress(Exception):
                     token_file.unlink(missing_ok=True)
-                except Exception:
-                    pass
                 return None
             return token
         except Exception:
@@ -303,10 +302,8 @@ class OAuthClientCredentialsAuthProvider:
                 ),
                 encoding="utf-8",
             )
-            try:
+            with contextlib.suppress(Exception):
                 os.chmod(token_file, 0o600)
-            except Exception:
-                pass
         except Exception:
             # Best-effort only.
             return
@@ -336,13 +333,11 @@ class OAuthClientCredentialsAuthProvider:
                 ),
                 encoding="utf-8",
             )
-            try:
+            # Best-effort permission hardening; ignore chmod failures (e.g. on non-POSIX
+            # filesystems or when permissions cannot be changed). The tarpit file
+            # still serves its purpose even without strict mode.
+            with contextlib.suppress(Exception):
                 os.chmod(tarpit, 0o600)
-            except Exception:
-                # Best-effort permission hardening; ignore chmod failures (e.g. on non-POSIX
-                # filesystems or when permissions cannot be changed). The tarpit file
-                # still serves its purpose even without strict mode.
-                pass
         except Exception:
             return
 
@@ -514,10 +509,8 @@ class AsyncOAuthClientCredentialsAuthProvider:
                 access_token=str(access_token), expires_at_epoch_s=float(expires_at)
             )
             if not self._is_valid(token):
-                try:
+                with contextlib.suppress(Exception):
                     token_file.unlink(missing_ok=True)
-                except Exception:
-                    pass
                 return None
             return token
         except Exception:
@@ -577,10 +570,8 @@ class AsyncOAuthClientCredentialsAuthProvider:
                 ),
                 encoding="utf-8",
             )
-            try:
+            with contextlib.suppress(Exception):
                 os.chmod(tarpit, 0o600)
-            except Exception:
-                pass
         except Exception:
             return
 

--- a/runtime/job_worker.py
+++ b/runtime/job_worker.py
@@ -572,7 +572,7 @@ class JobWorker:
 
     def _run_worker_loop(self):
         """Runs the dedicated event loop for async user code"""
-        assert self._worker_loop is not None
+        assert self._worker_loop is not None  # noqa: S101 — internal invariant on a loop we just created
         asyncio.set_event_loop(self._worker_loop)
         # Signal that the loop is fully owned by this thread and about to
         # start running. close() blocks on this so it can stop the loop
@@ -789,7 +789,7 @@ class JobWorker:
         if not self.running:
             self.running = True
             if self._startup_jitter_max_seconds > 0:
-                jitter = random.uniform(0, self._startup_jitter_max_seconds)
+                jitter = random.uniform(0, self._startup_jitter_max_seconds)  # noqa: S311 — startup jitter, not security-sensitive
                 self.logger.info(f"Worker '{self.config.worker_name}' delaying start by {jitter:.2f}s (jitter)")
                 self.polling_task = asyncio.create_task(self._start_with_jitter(jitter))
             else:
@@ -852,7 +852,7 @@ class JobWorker:
                 cancelling = getattr(current, "cancelling", lambda: 0)
                 if cancelling() > 0:
                     raise
-            except Exception:
+            except Exception:  # noqa: S110 — best-effort shutdown; non-cancellation errors are ignored
                 pass
 
         tasks = list(self._inflight_tasks)
@@ -1082,11 +1082,11 @@ class JobWorker:
                 await self.client.fail_job(
                     job_key=job_item.job_key,
                     data=JobFailRequest(
-                        error_message=f"System error: {str(e)}",
+                        error_message=f"System error: {e!s}",
                         retries=job_item.retries - 1 if job_item.retries else 0,
                     ),
                 )
-            except Exception:
+            except Exception:  # noqa: S110 — best-effort failure reporting; original error already handled
                 pass  # Best effort
         finally:
             self._decrement_active_jobs()

--- a/scripts/check_missing_ops.py
+++ b/scripts/check_missing_ops.py
@@ -37,7 +37,7 @@ for op_id, (method, path) in sorted(spec_ops.items()):
         # Check request body
         op = None
         methods_dict = spec["paths"][path]
-        for m, o in methods_dict.items():
+        for _m, o in methods_dict.items():
             if isinstance(o, dict) and o.get("operationId") == op_id:
                 op = o
                 break
@@ -45,7 +45,7 @@ for op_id, (method, path) in sorted(spec_ops.items()):
         rb_info = ""
         if op and "requestBody" in op:
             content = op["requestBody"].get("content", {})
-            for ct, si in content.items():
+            for _ct, si in content.items():
                 schema = si.get("schema", {})
                 if "$ref" in schema:
                     rb_info = f" body=$ref:{schema['$ref']}"

--- a/scripts/generate_config_reference.py
+++ b/scripts/generate_config_reference.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 # Also allow importing from the generated package (not strictly needed here).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "generated"))
 
-from runtime.configuration_resolver import CamundaSdkConfiguration  # noqa: E402
+from runtime.configuration_resolver import CamundaSdkConfiguration
 
 BEGIN_MARKER = "<!-- BEGIN_CONFIG_REFERENCE -->"
 END_MARKER = "<!-- END_CONFIG_REFERENCE -->"

--- a/tests/acceptance/test_configuration_resolver.py
+++ b/tests/acceptance/test_configuration_resolver.py
@@ -162,7 +162,7 @@ def test_auth_strategy_conflict_raises_when_both_oauth_and_basic_credentials_pre
         ConfigurationResolver,
     )
 
-    with pytest.raises(ValueError, match="Both OAuth.*and Basic auth"):
+    with pytest.raises(ValueError, match=r"Both OAuth.*and Basic auth"):
         ConfigurationResolver(
             environment={
                 "CAMUNDA_CLIENT_ID": "id",

--- a/tests/acceptance/test_deprecated_aliases.py
+++ b/tests/acceptance/test_deprecated_aliases.py
@@ -143,8 +143,8 @@ class TestV9UsagePatterns:
         models = importlib.import_module("camunda_orchestration_sdk.models")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            old_cls = getattr(models, "SearchUsersResponse200")
-        new_cls = getattr(models, "UserSearchResult")
+            old_cls = models.SearchUsersResponse200
+        new_cls = models.UserSearchResult
         assert old_cls is new_cls
         assert issubclass(new_cls, old_cls)  # type: ignore[arg-type]
 
@@ -153,8 +153,8 @@ class TestV9UsagePatterns:
         models = importlib.import_module("camunda_orchestration_sdk.models")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            old_cls = getattr(models, "GetUserResponse200")
-        new_cls = getattr(models, "UserResult")
+            old_cls = models.GetUserResponse200
+        new_cls = models.UserResult
         assert issubclass(old_cls, new_cls)  # type: ignore[arg-type]
         assert issubclass(new_cls, old_cls)  # type: ignore[arg-type]
 
@@ -171,7 +171,7 @@ class TestV9UsagePatterns:
         """__getattr__ must not swallow errors for genuinely missing names."""
         models = importlib.import_module("camunda_orchestration_sdk.models")
         with pytest.raises(AttributeError, match="TotallyBogusName"):
-            getattr(models, "TotallyBogusName")
+            _ = models.TotallyBogusName
 
 
 class TestRenameMapCompleteness:

--- a/tests/acceptance/test_eventual_consistency.py
+++ b/tests/acceptance/test_eventual_consistency.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -431,7 +431,7 @@ class TestGeneratedClientHasConsistencyParam:
     # ``eventuallyConsistent`` flag in spec-metadata.json). ``search_variables_as_dto``
     # re-reads the whole variable collection until every declared variable is
     # visible, so it is eventually consistent by design.
-    _CUSTOM_EVENTUAL_METHODS: set[str] = {"search_variables_as_dto"}
+    _CUSTOM_EVENTUAL_METHODS: ClassVar[set[str]] = {"search_variables_as_dto"}
 
     def _get_client_source(self) -> str:
         import importlib.resources

--- a/tests/acceptance/test_identifier_guard.py
+++ b/tests/acceptance/test_identifier_guard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import ast
 import importlib.util
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -252,7 +253,7 @@ class TestNoHookInterpolatesUnsafeIdentifiers:
     """
 
     # All hooks that interpolate spec-controlled strings into Python source
-    HOOKS_REQUIRING_GUARD = [
+    HOOKS_REQUIRING_GUARD: ClassVar[list[str]] = [
         "0150_annotate_deprecated_enums.py",
         "0200_raise_exceptions.py",
         "0700_generate_semantic_types.py",

--- a/tests/acceptance/test_imports.py
+++ b/tests/acceptance/test_imports.py
@@ -98,3 +98,60 @@ def test_nullable_list_parse_helpers_are_type_annotated():
     assert not offenders, (
         f"Nullable list parse helpers not type-annotated: {sorted(offenders)}"
     )
+
+
+def test_generated_code_has_no_return_in_finally():
+    """No generated module may put a ``return`` inside a ``finally`` block.
+
+    A ``return`` that exits a ``finally`` block is a ``SyntaxWarning`` on
+    Python <3.14 and a hard ``SyntaxError`` on 3.14+, which breaks import of
+    the generated package on newer interpreters. Guards the defect class where
+    a hook emits such a jump statement (e.g. the best-effort ``close()`` swallow
+    in hook ``0900_flatten_client``). Scans every generated module, not just the
+    one that regressed, so the same pattern cannot reappear elsewhere.
+    """
+    import ast
+    from pathlib import Path
+
+    # Parse the generated sources by path rather than importing the package:
+    # the guard is a pure syntax check and must run even when the committed
+    # tree is not import-clean.
+    pkg_dir = (
+        Path(__file__).resolve().parents[2]
+        / "generated"
+        / "camunda_orchestration_sdk"
+    )
+    assert pkg_dir.is_dir(), f"Generated package not found at {pkg_dir}"
+
+    def _returns_in_finalbody(finalbody: list[ast.stmt]) -> list[int]:
+        # Walk the ``finally`` suite but do not descend into nested scopes
+        # (functions/lambdas/classes), where a ``return`` binds to that inner
+        # scope and is therefore legal.
+        found: list[int] = []
+        stack: list[ast.AST] = list(finalbody)
+        while stack:
+            node = stack.pop()
+            if isinstance(
+                node,
+                (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef),
+            ):
+                continue
+            if isinstance(node, ast.Return):
+                found.append(node.lineno)
+            stack.extend(ast.iter_child_nodes(node))
+        return found
+
+    offenders: dict[str, list[int]] = {}
+    for py in pkg_dir.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        lines: list[int] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try) and node.finalbody:
+                lines.extend(_returns_in_finalbody(node.finalbody))
+        if lines:
+            offenders[py.relative_to(pkg_dir).as_posix()] = sorted(set(lines))
+
+    assert not offenders, (
+        "`return` inside a `finally` block (SyntaxError on Python 3.14+) in "
+        f"generated modules: {offenders}"
+    )

--- a/tests/acceptance/test_job_worker_resources.py
+++ b/tests/acceptance/test_job_worker_resources.py
@@ -168,13 +168,13 @@ def test_job_worker_concurrent_close_is_idempotent() -> None:
     _ = worker.thread_pool
 
     barrier = _threading.Barrier(4)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def race() -> None:
         try:
             barrier.wait(timeout=5.0)
             worker.close()
-        except BaseException as e:
+        except Exception as e:
             errors.append(e)
 
     threads = [_threading.Thread(target=race) for _ in range(4)]

--- a/tests/acceptance/test_job_worker_resources.py
+++ b/tests/acceptance/test_job_worker_resources.py
@@ -174,7 +174,7 @@ def test_job_worker_concurrent_close_is_idempotent() -> None:
         try:
             barrier.wait(timeout=5.0)
             worker.close()
-        except BaseException as e:  # noqa: BLE001 — propagate any race fallout
+        except BaseException as e:
             errors.append(e)
 
     threads = [_threading.Thread(target=race) for _ in range(4)]

--- a/tests/acceptance/test_mtls.py
+++ b/tests/acceptance/test_mtls.py
@@ -285,7 +285,7 @@ class TestBuildSslContext:
             CAMUNDA_MTLS_CERT_PATH=str(tmp_path / "nonexistent.crt"),
             CAMUNDA_MTLS_KEY_PATH=str(tmp_path / "nonexistent.key"),
         )
-        with pytest.raises(FileNotFoundError, match="nonexistent.crt"):
+        with pytest.raises(FileNotFoundError, match=r"nonexistent.crt"):
             build_ssl_context(config)
 
     def test_missing_key_file_raises(
@@ -295,5 +295,5 @@ class TestBuildSslContext:
             CAMUNDA_MTLS_CERT_PATH=str(cert_dir["cert"]),
             CAMUNDA_MTLS_KEY_PATH=str(tmp_path / "nonexistent.key"),
         )
-        with pytest.raises(FileNotFoundError, match="nonexistent.key"):
+        with pytest.raises(FileNotFoundError, match=r"nonexistent.key"):
             build_ssl_context(config)

--- a/tests/integration/test_job_worker.py
+++ b/tests/integration/test_job_worker.py
@@ -42,7 +42,8 @@ def callback(job: JobContext):
 @pytest.mark.asyncio
 async def test_job_worker_performance():
     async with _make_client() as camunda:
-        with open(
+        # Reading a small local fixture synchronously in a test setup is fine.
+        with open(  # noqa: ASYNC230
             "./tests/integration/resources/job_worker_load_test_process_1.bpmn", "rb"
         ) as f:
             process_file = File(

--- a/tests/integration/test_search_variables_as_dto.py
+++ b/tests/integration/test_search_variables_as_dto.py
@@ -35,7 +35,8 @@ def _make_client() -> CamundaAsyncClient:
 
 
 async def _deploy_process_definition_key(camunda: CamundaAsyncClient) -> str:
-    with open(_BPMN_PATH, "rb") as f:
+    # Reading a small local fixture synchronously in a test helper is fine.
+    with open(_BPMN_PATH, "rb") as f:  # noqa: ASYNC230
         process_file = File(payload=f, file_name="typed_variables_test_process.bpmn")
         deployed = await camunda.create_deployment(
             data=CreateDeploymentData(resources=[process_file])

--- a/tests/unit/test_semantic_types.py
+++ b/tests/unit/test_semantic_types.py
@@ -419,6 +419,6 @@ class TestCopyAndPickle:
     def test_pickle_round_trip(self) -> None:
         key = ProcessDefinitionKey("100")
         pickled = pickle.dumps(key)
-        unpickled: str = pickle.loads(pickled)  # noqa: S301
+        unpickled: str = pickle.loads(pickled)
         assert unpickled == key
         assert unpickled == "100"


### PR DESCRIPTION
## What?

Expand the ruff rule selection and treat warnings as errors in the test suite.

Closes #207.

### ruff config (`[tool.ruff.lint]`)

- `extend-select = ["B", "RUF", "ASYNC", "S"]` on top of ruff's defaults (E4/E7/E9, F):
  - **B** (flake8-bugbear) — likely bugs (loop-variable capture, `zip` without `strict`, …)
  - **RUF** — mutable class defaults, unsorted `__all__`, unused noqa, …
  - **ASYNC** — blocking calls inside async functions
  - **S** (flake8-bandit) — security scanning of production code paths
- `ignore = ["RUF001", "RUF002", "RUF003"]` — ambiguous-unicode checks fire on intentional
  typography and add no value.
- Per-file `S` ignores for surfaces where bandit's threat model does not apply: tests (asserts
  and fixtures), examples (illustrative fake credentials), and build/generation tooling
  (`generate.py`, `bundle.py`, `hooks/**`, `scripts/**`) which runs locally against
  developer-controlled, trusted inputs.
- `stubs/` is generated and now excluded from ruff, alongside `generated/`.

### pytest config (`[tool.pytest.ini_options]`)

- `filterwarnings = ["error"]` so deprecations and resource-leak warnings surface as failures.
- One narrowly-scoped ignore for `pytest.PytestUnraisableExceptionWarning` — those wrap
  `ResourceWarning`s surfaced non-deterministically during interpreter GC (e.g. a Windows
  `ProactorEventLoop` or a mock socket collected at teardown), not warnings the code under test
  emits synchronously, so they cannot be reliably asserted on.

### Findings fixed (not suppressed)

- **B905** — added `strict=False` to `zip()` in the flatten hook (behavior-preserving).
- **B023** — bound loop variables as default args in the two immediately-consumed replacer
  closures in the semantic-types hook.
- **B007** — renamed unused loop variables to `_`-prefixed in `check_missing_ops.py`.
- **B018 / RUF012 / RUF043** — assigned a useless expression, annotated mutable class attrs with
  `ClassVar`, and marked regex `match=` patterns as raw strings in tests.
- **S110** — converted best-effort `try/except/pass` blocks in `auth.py` to
  `contextlib.suppress(Exception)`; the two in `job_worker.py` (which have surrounding control
  flow) carry a justified `# noqa: S110`.
- **S101 / S311 / ASYNC230** — a small number of justified `# noqa`s (runtime invariant assert,
  non-cryptographic startup jitter, synchronous fixture reads in async tests).
- RUF-family autofixes (`RUF010`/`RUF022`, unused-noqa cleanup, `getattr` → attribute access).

## Validation

- `ruff check` — all checks pass.
- `ty check` — all checks pass.
- `pytest tests/acceptance` (533 passed, 1 skipped) and `pytest tests/unit` (80 passed) under
  `filterwarnings = ["error"]`.

No generated output (`generated/`, `stubs/`, `external-spec/`) is included.
