### PR TITLE
docs: add runtime backup and exporting examples

### DIFF
--- a/examples/backup.py
+++ b/examples/backup.py
@@ -12,8 +12,9 @@ from camunda_orchestration_sdk import (
 def take_runtime_backup_example(backup_id: int) -> None:
     client = CamundaClient()
 
-    # Omit `backup_id` when continuous backups or a backup/checkpoint schedule is
-    # enabled for the physical tenant -- the id is then generated automatically.
+    # `backup_id` is optional: leave it unset when continuous backups or a
+    # backup/checkpoint schedule is enabled and an id is generated for you.
+    # Here it is supplied explicitly, which is what a one-off manual backup does.
     result = client.take_runtime_backup(
         data=TakeRuntimeBackupRequest(
             backup_id=backup_id,

--- a/examples/backup.py
+++ b/examples/backup.py
@@ -1,0 +1,89 @@
+# Compilable usage examples for runtime backup operations.
+# These examples are type-checked during build to guard against API regressions.
+from __future__ import annotations
+
+from camunda_orchestration_sdk import (
+    CamundaClient,
+    TakeRuntimeBackupRequest,
+)
+
+# region TakeRuntimeBackup
+def take_runtime_backup_example(backup_id: int) -> None:
+    client = CamundaClient()
+
+    # Omit `backup_id` when continuous backups or a backup/checkpoint schedule is
+    # enabled for the physical tenant -- the id is then generated automatically.
+    result = client.take_runtime_backup(
+        data=TakeRuntimeBackupRequest(
+            backup_id=backup_id,
+        )
+    )
+
+    print(f"Scheduled backup {result.backup_id}")
+# endregion TakeRuntimeBackup
+
+# region ListRuntimeBackups
+def list_runtime_backups_example() -> None:
+    client = CamundaClient()
+
+    # `prefix` is a backup id prefix followed by a single `*` wildcard.
+    result = client.list_runtime_backups(prefix="17567*")
+
+    for backup in result:
+        print(f"Runtime backup: {backup}")
+# endregion ListRuntimeBackups
+
+# region GetRuntimeBackup
+def get_runtime_backup_example(backup_id: int) -> None:
+    client = CamundaClient()
+
+    result = client.get_runtime_backup(backup_id=backup_id)
+
+    print(f"Backup {result.backup_id} is {result.state.value}")
+
+    for partition in result.details:
+        print(f"  partition {partition.partition_id}: {partition.state.value}")
+# endregion GetRuntimeBackup
+
+# region DeleteRuntimeBackup
+def delete_runtime_backup_example(backup_id: int) -> None:
+    client = CamundaClient()
+
+    client.delete_runtime_backup(backup_id=backup_id)
+# endregion DeleteRuntimeBackup
+
+# region GetRuntimeBackupState
+def get_runtime_backup_state_example() -> None:
+    client = CamundaClient()
+
+    result = client.get_runtime_backup_state()
+
+    for checkpoint in result.checkpoint_states:
+        print(
+            f"Partition {checkpoint.partition_id} checkpoint {checkpoint.checkpoint_id}"
+            f" at position {checkpoint.checkpoint_position}"
+        )
+
+    for backup_range in result.ranges:
+        print(f"Partition {backup_range.partition_id} range: {backup_range.start} - {backup_range.end}")
+# endregion GetRuntimeBackupState
+
+# region SyncRuntimeBackupState
+def sync_runtime_backup_state_example() -> None:
+    client = CamundaClient()
+
+    # Force-writes the checkpoint and backup metadata of every partition to the
+    # backup store, independent of any backup being taken or confirmed.
+    result = client.sync_runtime_backup_state()
+
+    print(f"Synced {len(result.backup_states)} partition backup states")
+# endregion SyncRuntimeBackupState
+
+# region DeleteRuntimeBackupState
+def delete_runtime_backup_state_example() -> None:
+    client = CamundaClient()
+
+    # Clears all checkpoint info, backup info, checkpoint metadata, and backup
+    # ranges of every partition. Used when switching backup stores.
+    client.delete_runtime_backup_state()
+# endregion DeleteRuntimeBackupState

--- a/examples/backup.py
+++ b/examples/backup.py
@@ -7,6 +7,7 @@ from camunda_orchestration_sdk import (
     TakeRuntimeBackupRequest,
 )
 
+
 # region TakeRuntimeBackup
 def take_runtime_backup_example(backup_id: int) -> None:
     client = CamundaClient()
@@ -22,6 +23,7 @@ def take_runtime_backup_example(backup_id: int) -> None:
     print(f"Scheduled backup {result.backup_id}")
 # endregion TakeRuntimeBackup
 
+
 # region ListRuntimeBackups
 def list_runtime_backups_example() -> None:
     client = CamundaClient()
@@ -32,6 +34,7 @@ def list_runtime_backups_example() -> None:
     for backup in result:
         print(f"Runtime backup: {backup}")
 # endregion ListRuntimeBackups
+
 
 # region GetRuntimeBackup
 def get_runtime_backup_example(backup_id: int) -> None:
@@ -45,12 +48,14 @@ def get_runtime_backup_example(backup_id: int) -> None:
         print(f"  partition {partition.partition_id}: {partition.state.value}")
 # endregion GetRuntimeBackup
 
+
 # region DeleteRuntimeBackup
 def delete_runtime_backup_example(backup_id: int) -> None:
     client = CamundaClient()
 
     client.delete_runtime_backup(backup_id=backup_id)
 # endregion DeleteRuntimeBackup
+
 
 # region GetRuntimeBackupState
 def get_runtime_backup_state_example() -> None:
@@ -65,8 +70,12 @@ def get_runtime_backup_state_example() -> None:
         )
 
     for backup_range in result.ranges:
-        print(f"Partition {backup_range.partition_id} range: {backup_range.start} - {backup_range.end}")
+        print(
+            f"Partition {backup_range.partition_id} range:"
+            f" {backup_range.start} - {backup_range.end}"
+        )
 # endregion GetRuntimeBackupState
+
 
 # region SyncRuntimeBackupState
 def sync_runtime_backup_state_example() -> None:
@@ -78,6 +87,7 @@ def sync_runtime_backup_state_example() -> None:
 
     print(f"Synced {len(result.backup_states)} partition backup states")
 # endregion SyncRuntimeBackupState
+
 
 # region DeleteRuntimeBackupState
 def delete_runtime_backup_state_example() -> None:

--- a/examples/exporting.py
+++ b/examples/exporting.py
@@ -2,9 +2,8 @@
 # These examples are type-checked during build to guard against API regressions.
 from __future__ import annotations
 
-from camunda_orchestration_sdk import (
-    CamundaClient,
-)
+from camunda_orchestration_sdk import CamundaClient
+
 
 # region PauseExporting
 def pause_exporting_example() -> None:
@@ -15,6 +14,7 @@ def pause_exporting_example() -> None:
     # progressing -- for example while a backup is taken.
     client.pause_exporting(soft=True)
 # endregion PauseExporting
+
 
 # region ResumeExporting
 def resume_exporting_example() -> None:

--- a/examples/exporting.py
+++ b/examples/exporting.py
@@ -1,0 +1,24 @@
+# Compilable usage examples for exporting operations.
+# These examples are type-checked during build to guard against API regressions.
+from __future__ import annotations
+
+from camunda_orchestration_sdk import (
+    CamundaClient,
+)
+
+# region PauseExporting
+def pause_exporting_example() -> None:
+    client = CamundaClient()
+
+    # With `soft=True` exporting keeps running but its position is not committed,
+    # so the log is still not compacted. Use it when exporting must keep
+    # progressing -- for example while a backup is taken.
+    client.pause_exporting(soft=True)
+# endregion PauseExporting
+
+# region ResumeExporting
+def resume_exporting_example() -> None:
+    client = CamundaClient()
+
+    client.resume_exporting()
+# endregion ResumeExporting

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -62,6 +62,69 @@
             "label": "Restore from a backup"
         }
     ],
+    "take_runtime_backup": [
+        {
+            "file": "backup.py",
+            "region": "TakeRuntimeBackup",
+            "label": "Take a runtime backup"
+        }
+    ],
+    "list_runtime_backups": [
+        {
+            "file": "backup.py",
+            "region": "ListRuntimeBackups",
+            "label": "List runtime backups"
+        }
+    ],
+    "get_runtime_backup": [
+        {
+            "file": "backup.py",
+            "region": "GetRuntimeBackup",
+            "label": "Get a runtime backup"
+        }
+    ],
+    "delete_runtime_backup": [
+        {
+            "file": "backup.py",
+            "region": "DeleteRuntimeBackup",
+            "label": "Delete a runtime backup"
+        }
+    ],
+    "get_runtime_backup_state": [
+        {
+            "file": "backup.py",
+            "region": "GetRuntimeBackupState",
+            "label": "Get the runtime backup state"
+        }
+    ],
+    "sync_runtime_backup_state": [
+        {
+            "file": "backup.py",
+            "region": "SyncRuntimeBackupState",
+            "label": "Force-write the runtime backup state"
+        }
+    ],
+    "delete_runtime_backup_state": [
+        {
+            "file": "backup.py",
+            "region": "DeleteRuntimeBackupState",
+            "label": "Delete the runtime backup state"
+        }
+    ],
+    "pause_exporting": [
+        {
+            "file": "exporting.py",
+            "region": "PauseExporting",
+            "label": "Pause exporting"
+        }
+    ],
+    "resume_exporting": [
+        {
+            "file": "exporting.py",
+            "region": "ResumeExporting",
+            "label": "Resume exporting"
+        }
+    ],
     "get_status": [
         {
             "file": "admin_operations.py",


### PR DESCRIPTION
Closes #221

## What

Adds region-tagged examples for the nine new `Backup` and `Exporting` operations introduced in 8.10, restoring 100% operation example coverage.

**`examples/backup.py`** (new)

- `take_runtime_backup`
- `list_runtime_backups`
- `get_runtime_backup`
- `delete_runtime_backup`
- `get_runtime_backup_state`
- `sync_runtime_backup_state`
- `delete_runtime_backup_state`

**`examples/exporting.py`** (new)

- `pause_exporting`
- `resume_exporting`

Each region has a matching `examples/operation-map.json` entry.

## Scope

Hand-written example files only. `generated/`, `stubs/`, and `external-spec/bundled/` are regenerated by CI from upstream `main`, so no generated output is committed here — matching the precedent set by the `change_cluster_mode` and `resolve_secrets` example PRs.

## Validation

Run locally after bundling the upstream spec and regenerating:

- `scripts/check_example_coverage.py` — 213 operations, 213 covered, **100%**, integrity check passed
- `ty check examples/` — all checks passed
- `ruff check examples/backup.py examples/exporting.py` — all checks passed
- `pytest tests/acceptance` — 534 passed, 1 skipped

## Note

`list_runtime_backups` is generated as `-> list[Any]` because the response is a root-level array, so the example prints each entry rather than accessing typed attributes. This follows the existing `get_process_instance_call_hierarchy` precedent in `examples/extended_operations.py`.
