### PR TITLE
ci: only raise major-update PRs for vulnerability fixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,10 +15,19 @@
       "enabled": false
     },
     {
+      "description": "Do not raise routine major-update PRs. Renovate's vulnerability remediation bypasses packageRules by design, so a major is still raised when it is the lowest version that fixes a known vulnerability.",
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "Auto-merge minor and patch updates once CI is green.",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ],
-  "vulnerabilityAlerts": { "enabled": false }
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "vulnerabilityFixStrategy": "lowest"
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
## What

Major-version PRs are no longer raised routinely — only when a major is required to fix a vulnerability.

```jsonc
// new packageRule
{
  "matchUpdateTypes": ["major"],
  "enabled": false
}

// vulnerability path stays open
"vulnerabilityAlerts": { "enabled": true, "vulnerabilityFixStrategy": "lowest" },
"osvVulnerabilityAlerts": true
```

## Why this works

Renovate's vulnerability remediation **deliberately bypasses `packageRules` update-type restrictions** — that behaviour is the subject of [renovatebot/renovate discussion #40134](https://github.com/renovatebot/renovate/discussions/40134), where a user reports majors *still* being raised for security despite `matchUpdateTypes: ["major"] + enabled: false`, and a maintainer confirms security-update config belongs inside `vulnerabilityAlerts`. So disabling majors in `packageRules` suppresses routine majors while leaving the vulnerability path intact.

`vulnerabilityFixStrategy: "lowest"` (the schema default, now explicit) means Renovate bumps only as far as needed to clear the advisory — so a major happens only when no patch/minor fixes it. That is exactly "major only if the vulnerability needs it".

## Also enabled here

`vulnerabilityAlerts` / `osvVulnerabilityAlerts` are ensured on. Worth knowing: **GitHub's Dependabot security updates are `enabled: false` on all four repos**, so Renovate is the only automated remediation path — and `vulnerabilityAlerts` was still `false` in this repo's config (it had been switched on in the C# and JS repos by later commits, but not here). `osvVulnerabilityAlerts` adds OSV-based detection that does not depend on GitHub Dependabot alerts being enabled (they appear to be off on camunda-8-js-sdk).

## Visibility

Suppressed majors are still listed in the Dependency Dashboard issue, so they can be taken manually whenever wanted — nothing goes silently unnoticed.

(Same change applied to all four repos.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
