### PR TITLE
ci: add spec-ref-guard job to stable/9 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,16 @@ on:
         default: ""
 
 jobs:
+  spec-ref-guard:
+    uses: camunda/sdk-infra/.github/workflows/sdk-spec-ref-guard.yml@v1
+    with:
+      spec-ref: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
+      default-ref: 'stable/8.9'
+      ack: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
+      expires: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
+
   test:
+    needs: spec-ref-guard
     runs-on: ubuntu-latest
     env:
       # Default is stable/8.9 for this branch (pinned to Camunda 8.9 spec).
@@ -25,36 +34,12 @@ jobs:
       # - Repo variable: SPEC_REF_OVERRIDE
       # - Manual run: workflow_dispatch input spec_ref
       SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
-      SPEC_REF_OVERRIDE_ACK: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
-      SPEC_REF_OVERRIDE_EXPIRES: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - name: Guard spec ref override
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "SPEC_REF=${SPEC_REF}"
 
-          # stable/8.9 is the expected default for this branch — only guard
-          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
-          if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
-            if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
-              echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."
-              exit 1
-            fi
-            if [[ -z "${SPEC_REF_OVERRIDE_EXPIRES}" ]]; then
-              echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_EXPIRES is not set (expected YYYY-MM-DD)."
-              exit 1
-            fi
-            today="$(date -u +%F)"
-            if [[ "${today}" > "${SPEC_REF_OVERRIDE_EXPIRES}" ]]; then
-              echo "::error::SPEC_REF override expired on ${SPEC_REF_OVERRIDE_EXPIRES}. Remove SPEC_REF_OVERRIDE (or extend expiry) now that upstream main should be fixed."
-              exit 1
-            fi
-          fi
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 


### PR DESCRIPTION
## Problem

Every Renovate PR targeting `stable/9` is stuck at `mergeStateStatus: BLOCKED` with **zero failing checks** (#226, #227, #228).

The **Protect stable branches** ruleset (`refs/heads/stable/**`) requires the status check `spec-ref-guard / guard`. `stable/9`'s `ci.yml` never produced a check by that name — the spec-ref override guard was an inline *step* inside the `test` job (added in 3abf3d12), not a reusable-workflow job.

So the check never reports, and the PRs wait on it forever.

This is drift: `main` was refactored onto the `camunda/sdk-infra` reusable workflows (`spec-ref-guard` job calling inner job `guard`), and the ruleset was written against main's check names. `stable/9` never got that refactor.

## Change

- Add a `spec-ref-guard` job calling `camunda/sdk-infra/.github/workflows/sdk-spec-ref-guard.yml@v1`, matching main's `ci.yml`, with `default-ref: stable/8.9` to preserve this branch's spec pin.
- `test` now `needs: spec-ref-guard`.
- Drop the now-redundant inline guard step and the `SPEC_REF_OVERRIDE_ACK` / `SPEC_REF_OVERRIDE_EXPIRES` job env (only the inline step read them). `SPEC_REF` stays — `Makefile` / `scripts/bundle-spec.sh` consume it.

Guard behaviour is unchanged: it only fires when `SPEC_REF_OVERRIDE` moves the ref off `stable/8.9`, and still demands `ACK` plus an unexpired `EXPIRES`.

## Verification

`pull_request` runs the workflow from the merge ref, so this PR reports the new `spec-ref-guard / guard` check on itself — no chicken-and-egg with the ruleset.

## Follow-up

After merge, #226, #227 and #228 need a rebase to pick up the new job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)