### PR TITLE
ci: pin publish SPEC_REF default to stable/8.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,8 @@ jobs:
           echo "SPEC_REF=${SPEC_REF}"
 
           # stable/8.9 is the expected default for this branch — only guard
-          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
+          # if SPEC_REF_OVERRIDE or the workflow_dispatch spec_ref input
+          # moves it to something else.
           if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
             if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
               echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."
@@ -118,7 +119,8 @@ jobs:
           echo "SPEC_REF=${SPEC_REF}"
 
           # stable/8.9 is the expected default for this branch — only guard
-          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
+          # if SPEC_REF_OVERRIDE or the workflow_dispatch spec_ref input
+          # moves it to something else.
           if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
             if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
               echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
+      # Default is stable/8.9 for this branch (pinned to Camunda 8.9 spec).
+      # Temporary override options:
+      # - Repo variable: SPEC_REF_OVERRIDE
+      # - Manual run: workflow_dispatch input spec_ref
+      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
       SPEC_REF_OVERRIDE_ACK: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
       SPEC_REF_OVERRIDE_EXPIRES: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
     strategy:
@@ -37,7 +41,9 @@ jobs:
           set -euo pipefail
           echo "SPEC_REF=${SPEC_REF}"
 
-          if [[ "${SPEC_REF}" != "main" ]]; then
+          # stable/8.9 is the expected default for this branch — only guard
+          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
+          if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
             if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
               echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."
               exit 1
@@ -90,7 +96,11 @@ jobs:
     permissions:
       contents: write
     env:
-      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'main' }}
+      # Default is stable/8.9 for this branch (pinned to Camunda 8.9 spec).
+      # Temporary override options:
+      # - Repo variable: SPEC_REF_OVERRIDE
+      # - Manual run: workflow_dispatch input spec_ref
+      SPEC_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.spec_ref) || vars.SPEC_REF_OVERRIDE || 'stable/8.9' }}
       SPEC_REF_OVERRIDE_ACK: ${{ vars.SPEC_REF_OVERRIDE_ACK || '' }}
       SPEC_REF_OVERRIDE_EXPIRES: ${{ vars.SPEC_REF_OVERRIDE_EXPIRES || '' }}
     outputs:
@@ -107,7 +117,9 @@ jobs:
           set -euo pipefail
           echo "SPEC_REF=${SPEC_REF}"
 
-          if [[ "${SPEC_REF}" != "main" ]]; then
+          # stable/8.9 is the expected default for this branch — only guard
+          # if someone overrides it to something else via SPEC_REF_OVERRIDE.
+          if [[ "${SPEC_REF}" != "stable/8.9" ]]; then
             if [[ "${SPEC_REF_OVERRIDE_ACK}" != "true" ]]; then
               echo "::error::SPEC_REF is overridden but SPEC_REF_OVERRIDE_ACK is not 'true'. Set the repo variable to acknowledge this is temporary."
               exit 1


### PR DESCRIPTION
## Problem

Publish failed on `stable/9` ([run 30508380553](https://github.com/camunda/orchestration-cluster-api-python/actions/runs/30508380553)) with 114 typecheck errors in `make generate`:

```
error: "LoopIterationId" is unknown import symbol
error: Arguments missing for parameters "physical_tenant_id", "business_id", "priority", "lease_token"
error: Argument of type "Literal['orderId']" cannot be assigned to parameter "name" of type "ClusterVariableName"
make: *** [Makefile:24: generate] Error 1
```

Every one of those symbols is an 8.10 addition. This branch is pinned to the 8.9 spec.

## Root cause

3abf3d12 ("pin SPEC_REF default to stable/8.9 for stable/9 branch") pinned `ci.yml` but missed `publish.yml`, which kept `SPEC_REF` defaulting to `'main'` in both the `test` and `generate` jobs.

So publish fetched the OpenAPI spec from `camunda/camunda` `main` — now 8.10-SNAPSHOT — regenerated the SDK against it, and typechecked the result against this branch's 8.9-pinned tests and stubs.

`Makefile:5` already defaults to `SPEC_REF ?= stable/8.9`, so local `make generate` was always correct. Only the workflow's explicit `main` override broke.

## Why it surfaced now

| stable/9 publish run | result | date |
|---|---|---|
| 24417233240 | success | 2026-04-14 |
| 25142727006 | success | 2026-04-30 01:32 |
| 30508380553 | **failure** | 2026-07-30 |

3abf3d12 landed 2026-04-30 12:47 — hours after the last green run. `stable/9` then saw no pushes for three months, so publish never ran and the gap stayed hidden. Merging #233 was the first push since.

## Change

`'main'` → `'stable/8.9'` in both job envs, and the two override-guard comparisons flipped to match. Comments mirror the wording 3abf3d12 used in `ci.yml`.

Four functional lines. Guard behaviour is otherwise unchanged: it fires only when `SPEC_REF_OVERRIDE` moves the ref off the branch default, and still demands `ACK` plus an unexpired `EXPIRES`.

## Follow-up

`publish.yml` still carries that guard block inline, duplicated across two jobs. Worth collapsing onto `camunda/sdk-infra`'s `sdk-spec-ref-guard.yml@v1` — the way `main` does, and the way #233 just did for this branch's `ci.yml` — so this class of drift stops recurring. Left out here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)