### PR TITLE
ci: scope and reorder workflow credentials for INC-7027

### DIFF
--- a/.github/workflows/agent-pr-followup.yml
+++ b/.github/workflows/agent-pr-followup.yml
@@ -192,28 +192,6 @@ jobs:
       issues: write          # the outcome comment goes through the Issues API
       actions: read          # `gh run view --log-failed` reads the failing run's log
     steps:
-      - name: Import secrets
-        id: secrets
-        uses: hashicorp/vault-action@v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          path: ${{ secrets.VAULT_JWT_PATH }}
-          role: ${{ secrets.VAULT_JWT_ROLE }}
-          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_ID | APP_ID ;
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_PRIVATE_KEY | APP_PRIVATE_KEY ;
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
-          private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Check out the agent branch
         uses: actions/checkout@v6
         with:
@@ -242,6 +220,31 @@ jobs:
           COPILOT_CLI_VERSION: ${{ vars.COPILOT_CLI_VERSION || 'latest' }}
         run: npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
 
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: jwt
+          path: ${{ secrets.VAULT_JWT_PATH }}
+          role: ${{ secrets.VAULT_JWT_ROLE }}
+          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_ID | APP_ID ;
+            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_PRIVATE_KEY | APP_PRIVATE_KEY ;
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ steps.secrets.outputs.APP_ID }}
+          private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Scope the installation token to this repository. See INC-7027.
+          repositories: ${{ github.event.repository.name }}
+
+      # Credentials are minted after the dependency installs above. See INC-7027.
       - name: Configure committer identity
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}


### PR DESCRIPTION
Workflow credential-handling hardening.

Tracked under **INC-7027** — rationale, analysis and review notes are in the incident ticket and are intentionally not repeated here.

**Not tested.** YAML and step ordering were validated; the runtime path has not been exercised. Please confirm on a throwaway run before merging.

Questions to the incident channel or the ticket, please — not this thread.
