### PR TITLE
ci: use the shared agent example-coverage workflows

### DIFF
--- a/.github/workflows/agent-example-coverage.yml
+++ b/.github/workflows/agent-example-coverage.yml
@@ -1,22 +1,11 @@
-name: Agent — example coverage
-
 # Resolves the auto-filed "Missing example coverage" issues (label `new-operations`)
 # by running the Copilot CLI in CI and opening a pull request with the result.
 #
-# Why not assign the Copilot coding agent to the issue instead? Assigning it
-# requires a user PAT — GitHub does not support bot/App tokens for that API
-# (https://github.com/github/gh-aw/issues/19765), and PATs are not permitted
-# here. Running the agent inside Actions avoids tokens entirely:
-#
-#   * `copilot-requests: write` lets the Copilot CLI authenticate with the
-#     built-in GITHUB_TOKEN, billed to the organization. No PAT, no API key.
-#   * The branch push and the pull request are made with a Vault-minted GitHub
-#     App installation token, so the PR is authored by the app and its CI runs
-#     without a manual "approve workflows" step (a PR opened with GITHUB_TOKEN
-#     does not trigger workflows).
-#
-# Mirrors the proven pattern in camunda/infra-core
-# (.github/workflows/agent-stale-workaround-reaper.yml).
+# The mechanics live in camunda/sdk-infra so all five SDKs share one implementation;
+# this file supplies only what is genuinely repo-specific: the toolchain to install
+# and the commands that define "verified" here.
+
+name: Agent — example coverage
 
 on:
   issues:
@@ -32,293 +21,34 @@ on:
 
 permissions: {}
 
-env:
-  # Single source of truth for what "verified" means. The verify step runs exactly
-  # this, and the agent prompt is handed exactly this, so the agent cannot mistake a
-  # green lint or test run for a passing gate — and the two cannot drift apart.
-  VERIFY_COMMANDS: |
-    uv run python scripts/check_example_coverage.py
-    uv run python scripts/check_method_example_completeness.py
-    make lint
-    make typecheck
-    make sync-readme-check
-    make test
-# One agent run per issue at a time; a re-label must not race a running agent.
-concurrency:
-  group: agent-example-coverage-${{ github.event.issue.number || inputs.issue-number }}
-  cancel-in-progress: false
-
 jobs:
   implement:
-    # Only for `new-operations` issues: on the label being added, on an issue
-    # opened already carrying it, or on an explicit manual dispatch.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.action == 'labeled' && github.event.label.name == 'new-operations')
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
     permissions:
       contents: read           # checkout; the app token does the pushing
       id-token: write          # mint GitHub OIDC token for Vault JWT auth
-      copilot-requests: write  # required for Copilot CLI GITHUB_TOKEN auth (billed to the org)
+      copilot-requests: write  # Copilot CLI auth via GITHUB_TOKEN (billed to the org)
       issues: write            # report the outcome back on the issue
-    steps:
-      - name: Import secrets
-        id: secrets
-        uses: hashicorp/vault-action@v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          path: ${{ secrets.VAULT_JWT_PATH }}
-          role: ${{ secrets.VAULT_JWT_ROLE }}
-          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_ID | APP_ID ;
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_PRIVATE_KEY | APP_PRIVATE_KEY ;
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
-          private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          # Deliberately check out with the read-only job token and do NOT persist
-          # credentials: the agent runs with `--yolo`, so no write credential may sit
-          # in git config while it works. The app token is introduced only in the
-          # push step, via an explicit remote URL.
-          token: ${{ github.token }}
-          persist-credentials: false
-          fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@v7
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Install project dependencies
-        run: uv sync --all-extras --dev
-
-      - name: Install Copilot CLI
-        env:
-          # Pin deliberately by setting the COPILOT_CLI_VERSION repository variable
-          # (e.g. `0.0.x`); defaults to `latest` when unset.
-          COPILOT_CLI_VERSION: ${{ vars.COPILOT_CLI_VERSION || 'latest' }}
-        run: npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
-
-      - name: Configure committer identity
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          git config --global user.name "${APP_SLUG}[bot]"
-          git config --global user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-
-      - name: Resolve issue and create branch
-        id: setup
-        env:
-          # Read-only issue lookup: use the job token (already has issues: write) so
-          # the app does not need Issues permissions. The app token is reserved for
-          # pushing the branch and opening the PR.
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
-        run: |
-          set -euo pipefail
-
-          # workflow_dispatch takes a free-form string; reject anything that is not a
-          # plain issue number before it reaches gh or a git branch name.
-          if ! printf '%s' "$ISSUE_NUMBER" | grep -Eq '^[0-9]+$'; then
-            echo "::error::issue-number must be digits only; got '${ISSUE_NUMBER}'."
-            exit 1
-          fi
-
-          body="$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')"
-          title="$(gh issue view "$ISSUE_NUMBER" --json title --jq '.title')"
-          branch="agent/example-coverage-${ISSUE_NUMBER}"
-
-          # Re-labelling or a re-dispatch must not start a second agent run for an
-          # issue that already has an open PR: that burns a Copilot run and races
-          # the first run's branch.
-          existing_pr="$(gh pr list --repo "$GH_REPO" --head "$branch" --state open \
-            --json url,headRepositoryOwner \
-            --jq "[.[] | select(.headRepositoryOwner.login == \"${GITHUB_REPOSITORY_OWNER}\")] | .[0].url // empty")"
-          if [ -n "$existing_pr" ]; then
-            echo "::notice::${existing_pr} is already open for this issue; skipping the agent run."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-          git switch -c "$branch"
-
-          {
-            echo "issue-number=${ISSUE_NUMBER}"
-            echo "branch=${branch}"
-          } >> "$GITHUB_OUTPUT"
-
-          # The title and body are issue-controlled, so neither is written to
-          # $GITHUB_OUTPUT: any delimiter, fixed or random, is a collision surface
-          # that a crafted issue title could exploit. A file has no such format
-          # to escape, and the body already needed one to keep its markdown intact.
-          printf '%s\n' "$title" > /tmp/issue-title.txt
-          printf '%s\n' "$body" > /tmp/issue-body.md
-
-      - name: Run Copilot CLI
-        if: steps.setup.outputs.skip != 'true'
-        env:
-          # Built-in token authenticates the Copilot CLI, billed to the org.
-          # It is deliberately NOT used to push or open the PR.
-          GITHUB_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ steps.setup.outputs.issue-number }}
-        run: |
-          set -euo pipefail
-          # The issue body is author-controlled, so it is never interpolated into a
-          # heredoc: a line equal to the terminator would truncate or rewrite the
-          # prompt. Static parts use quoted heredocs; the body is spliced in as data.
-          {
-            cat <<'PROMPT_HEAD'
-          You are resolving the SDK example-coverage issue identified below.
-
-          Read AGENTS.md first and follow it strictly. Also read
-          .github/prompts/add-missing-examples.prompt.md if it exists — it documents the
-          example conventions in detail.
-          PROMPT_HEAD
-            echo ""
-            echo "  Repository: ${GITHUB_REPOSITORY}"
-            echo "  Issue: #${ISSUE_NUMBER}"
-            echo ""
-            echo "  Issue body:"
-            sed 's/^/  /' /tmp/issue-body.md
-            cat <<'PROMPT_TAIL'
-
-          Do the following:
-          1. For each operation listed in the issue, add a region-tagged example under
-             examples/, copying the exact structure of an existing example in the matching
-             domain file, and add the corresponding examples/operation-map.json entry.
-          2. Never hand-edit generated code. If the SDK does not yet expose an operation,
-             regenerate it with the repo pipeline documented in AGENTS.md and commit the
-             regenerated output separately from hand-written changes.
-          3. Commit with Conventional Commits messages that pass commitlint: an allowed type,
-             lower-case imperative subject, 5-100 characters. Never use 'fix:' for something
-             that is not a user-facing bug fix, and never add 'BREAKING CHANGE:' markers.
-          4. Stay inside the example surface: examples/, examples/operation-map.json, any
-             docs the repo requires for a new operation, and regenerated SDK output. Do
-             NOT modify generator sources (hooks/, scripts/, the generator project). If
-             the pipeline itself looks like it needs changing, stop and explain that in
-             your final message instead of editing it.
-          5. Commit every change you make and leave the working tree clean — uncommitted
-             work is discarded and fails the run.
-          6. Read AGENTS.md for the build/verification pipeline, then finish by running
-             the exact commands below. They are the gate this workflow applies: a green
-             lint, typecheck or test run does NOT mean they pass. Do not stop until
-             every one of them passes.
-          PROMPT_TAIL
-            # $( ) strips every trailing newline, so the blank line before the
-            # closing instruction is emitted here and does not depend on how
-            # VERIFY_COMMANDS happens to be quoted.
-            printf '%s\n\n' "$(printf '%s' "$VERIFY_COMMANDS" | sed 's/^/      /')"
-            cat <<'PROMPT_FOOT'
-          Do not push and do not open a pull request — the workflow does that.
-          PROMPT_FOOT
-          } > /tmp/prompt.md
-
-          copilot --yolo -p "$(cat /tmp/prompt.md)" --model claude-sonnet-4.6
-
-      - name: Verify example coverage
-        if: steps.setup.outputs.skip != 'true'
-        id: verify
-        run: |
-          # `:?` so an empty or unset constant aborts here: `bash -c ""` exits 0,
-          # which would turn a missing gate into a silently passing one.
-          bash -euo pipefail -c "${VERIFY_COMMANDS:?is empty; refusing to run an empty verify gate}"
-
-      - name: Push branch and open pull request
-        id: pr
-        if: steps.setup.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          BRANCH: ${{ steps.setup.outputs.branch }}
-          ISSUE_NUMBER: ${{ steps.setup.outputs.issue-number }}
-          BASE: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          TITLE="$(cat /tmp/issue-title.txt)"
-
-          # The agent is instructed to commit its work. A dirty tree means it did
-          # not, so fail loudly rather than opening a PR that omits the changes.
-          if ! git diff --quiet || ! git diff --cached --quiet; then
-            echo "::error::The agent left uncommitted changes in the working tree; refusing to open a partial PR."
-            git status --short
-            exit 1
-          fi
-
-          ahead="$(git rev-list --count "origin/${BASE}..HEAD")"
-          if [ "$ahead" -eq 0 ]; then
-            echo "::warning::The agent produced no commits; nothing to open a PR for."
-            echo "opened=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Agent produced ${ahead} commit(s)."
-
-          # Push with the app token supplied inline, so a write credential is never
-          # persisted in git config (see the checkout step).
-          git push --force-with-lease \
-            "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" \
-            "HEAD:refs/heads/${BRANCH}"
-
-          # A re-run pushes to the same branch, where an open PR may already exist.
-          # `gh pr create` would exit non-zero there, failing the job and dropping the
-          # link from the issue comment even though the push succeeded. Reuse it.
-          existing="$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --state open \
-            --json url,headRepositoryOwner \
-            --jq "[.[] | select(.headRepositoryOwner.login == \"${GITHUB_REPOSITORY_OWNER}\")] | .[0].url // empty")"
-          if [ -n "$existing" ]; then
-            echo "Updated existing pull request: $existing"
-            echo "opened=true" >> "$GITHUB_OUTPUT"
-            echo "url=${existing}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          url="$(gh pr create \
-            --base "$BASE" \
-            --head "$BRANCH" \
-            --title "feat: add example coverage for ${TITLE#Missing example coverage: }" \
-            --body "Resolves #${ISSUE_NUMBER}.
-
-          Generated by the Copilot CLI in CI (\`agent-example-coverage\` workflow), following AGENTS.md and the repo's example conventions. Coverage check and example build passed before this PR was opened — please still review the example bodies for correctness and idiomatic style.")"
-
-          echo "opened=true" >> "$GITHUB_OUTPUT"
-          echo "url=${url}" >> "$GITHUB_OUTPUT"
-
-      - name: Report outcome on the issue
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
-          RESULT: ${{ job.status }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-          OPENED: ${{ steps.pr.outputs.opened }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          if [ "$RESULT" = "success" ] && [ "${OPENED:-false}" = "true" ]; then
-            msg="🤖 Opened ${PR_URL} with example coverage for this issue. Coverage check and example build passed; please review."
-          elif [ "$RESULT" = "success" ]; then
-            msg="🤖 The agent ran but produced no changes — see the [run log](${RUN_URL}). This issue needs a human look."
-          else
-            msg="🤖 The agent run failed — see the [run log](${RUN_URL}). Re-run it with the \`Agent — example coverage\` workflow (\`workflow_dispatch\`, issue number \`${ISSUE_NUMBER}\`), or implement the coverage manually."
-          fi
-          gh issue comment "$ISSUE_NUMBER" --body "$msg" || echo "::warning::Could not comment on issue #${ISSUE_NUMBER}."
+    uses: camunda/sdk-infra/.github/workflows/sdk-agent-example-coverage.yml@v1
+    # Explicit rather than `inherit`: the shared workflow needs only Vault auth,
+    # and this job hands the repo to an LLM agent.
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
+      VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
+      VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
+    with:
+      language: python
+      issue-number: ${{ github.event.issue.number || inputs.issue-number }}
+      verify-commands: |
+        uv run python scripts/check_example_coverage.py
+        uv run python scripts/check_method_example_completeness.py
+        make lint
+        make typecheck
+        make sync-readme-check
+        make test
+      # `uv run` resolves the environment and may re-pin the lockfile.
+      verify-artifacts: |
+        uv.lock

--- a/.github/workflows/agent-pr-followup.yml
+++ b/.github/workflows/agent-pr-followup.yml
@@ -1,22 +1,11 @@
-name: Agent — PR follow-up
+# Reacts to feedback on an agent-authored pull request: a `/agent fix` comment,
+# a failing CI run, or a review from another bot.
+#
+# The mechanics live in camunda/sdk-infra so all five SDKs share one implementation;
+# this file supplies only what is genuinely repo-specific: the name of the CI
+# workflow to watch, the toolchain to install, and the verification commands.
 
-# The example-coverage agent opens a PR and then goes silent: it cannot react to a
-# CI failure or to review feedback. This workflow closes that loop by re-running the
-# Copilot CLI on an existing agent branch.
-#
-# Three ways in:
-#   1. `/agent fix [instructions]` in a PR comment — human-directed, uncapped.
-#   2. A CI run failing on an agent branch — automatic.
-#   3. A review submitted by a *different* bot reviewer (e.g. the Copilot PR
-#      reviewer) — automatic. A second opinion catches things the author missed.
-#
-# The two automatic paths share a hard attempt cap (see MAX_AUTO_ATTEMPTS) tracked
-# with `agent-attempt-N` labels, so a fix → CI → fix → review → fix chain always
-# terminates instead of burning Copilot runs in a loop. Human `/agent fix` bypasses
-# the cap, because a person is deciding each time.
-#
-# Only branches matching `agent/example-coverage-*` are eligible, and the agent
-# never reacts to its own output.
+name: Agent — PR follow-up
 
 on:
   issue_comment:
@@ -24,385 +13,39 @@ on:
   pull_request_review:
     types: [submitted]
   workflow_run:
-    workflows: ["CI"]
+    # Named here rather than in the shared workflow because each SDK repo calls
+    # its CI workflow something different.
+    workflows: ['CI']
     types: [completed]
 
 permissions: {}
 
-env:
-  MAX_AUTO_ATTEMPTS: '2'
-  AGENT_BRANCH_PREFIX: agent/example-coverage-
-  # Single source of truth for what "verified" means. The verify step runs exactly
-  # this, and the agent prompt is handed exactly this, so the agent cannot mistake a
-  # green lint or test run for a passing gate — and the two cannot drift apart.
-  VERIFY_COMMANDS: |
-    uv run python scripts/check_example_coverage.py
-    uv run python scripts/check_method_example_completeness.py
-    make lint
-    make typecheck
-    make sync-readme-check
-    make test
-concurrency:
-  group: agent-followup-${{ github.event.issue.number || github.event.pull_request.number || github.event.workflow_run.head_branch }}
-  cancel-in-progress: false
-
 jobs:
-  triage:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
+  followup:
     permissions:
       contents: read
-      pull-requests: write   # attempt labels
-      issues: write          # PR labels and comments go through the Issues API
-    outputs:
-      eligible: ${{ steps.decide.outputs.eligible }}
-      pr: ${{ steps.decide.outputs.pr }}
-      branch: ${{ steps.decide.outputs.branch }}
-      reason: ${{ steps.decide.outputs.reason }}
-    steps:
-      - name: Decide whether to run the agent
-        id: decide
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          EVENT: ${{ github.event_name }}
-          # issue_comment
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
-          COMMENT_ASSOC: ${{ github.event.comment.author_association }}
-          IS_PR: ${{ github.event.issue.pull_request != null }}
-          ISSUE_PR_NUMBER: ${{ github.event.issue.number }}
-          # pull_request_review
-          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
-          REVIEW_STATE: ${{ github.event.review.state }}
-          REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
-          # workflow_run
-          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-        run: |
-          set -euo pipefail
-          echo "eligible=false" >> "$GITHUB_OUTPUT"
-
-          # Never react to our own output, or to any actor that this workflow drives.
-          is_self() {
-            case "$1" in
-              github-actions\[bot\]|camunda-sdk-automation\[bot\]) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          pr=""; reason=""; capped="true"
-
-          case "$EVENT" in
-            issue_comment)
-              [ "$IS_PR" = "true" ] || { echo "Not a PR comment."; exit 0; }
-              is_self "$COMMENT_AUTHOR" && { echo "Own comment; ignoring."; exit 0; }
-              # The command must open the comment (leading whitespace allowed) rather
-              # than appear anywhere in it, so prose that merely mentions the command
-              # — "please don't /agent fix this" — cannot start a privileged run.
-              first_line="$(printf '%s\n' "$COMMENT_BODY" | head -n 1 | sed 's/^[[:space:]]*//')"
-              case "$first_line" in
-                "/agent fix"*) ;;
-                *) echo "Comment does not start with /agent fix."; exit 0 ;;
-              esac
-              # This command mints an App token and runs Copilot with --yolo, so it
-              # must not be steerable by arbitrary commenters on a public repo.
-              case "$COMMENT_ASSOC" in
-                OWNER|MEMBER|COLLABORATOR) ;;
-                *)
-                  echo "::warning::/agent fix from ${COMMENT_AUTHOR} (${COMMENT_ASSOC}) ignored — not a repo collaborator."
-                  gh pr comment "$ISSUE_PR_NUMBER" --repo "$GH_REPO" --body \
-                    "🤖 Only repository collaborators can run \`/agent fix\`." \
-                    || echo "::warning::Could not comment."
-                  exit 0
-                  ;;
-              esac
-              pr="$ISSUE_PR_NUMBER"
-              reason="comment"
-              capped="false"   # a human asked for this explicitly
-              ;;
-            pull_request_review)
-              [ "$REVIEW_STATE" != "approved" ] || { echo "Approving review; nothing to fix."; exit 0; }
-              is_self "$REVIEW_AUTHOR" && { echo "Own review; ignoring."; exit 0; }
-              case "$REVIEW_AUTHOR" in
-                *\[bot\]) ;;   # a second-opinion bot review is exactly what we want
-                *) echo "Human review: leave it to /agent fix so the reviewer stays in control."; exit 0 ;;
-              esac
-              pr="$REVIEW_PR_NUMBER"
-              reason="review"
-              ;;
-            workflow_run)
-              [ "$RUN_CONCLUSION" = "failure" ] || { echo "CI did not fail."; exit 0; }
-              case "$RUN_HEAD_BRANCH" in
-                "${AGENT_BRANCH_PREFIX}"*) ;;
-                *) echo "Not an agent branch."; exit 0 ;;
-              esac
-              pr="$(gh pr list --repo "$GH_REPO" --head "$RUN_HEAD_BRANCH" --state open \
-                --json number,headRepositoryOwner \
-                --jq "[.[] | select(.headRepositoryOwner.login == \"${GITHUB_REPOSITORY_OWNER}\")] | .[0].number // empty")"
-              [ -n "$pr" ] || { echo "No open PR for ${RUN_HEAD_BRANCH}."; exit 0; }
-              reason="ci"
-              ;;
-          esac
-
-          branch="$(gh pr view "$pr" --repo "$GH_REPO" --json headRefName --jq '.headRefName')"
-          case "$branch" in
-            "${AGENT_BRANCH_PREFIX}"*) ;;
-            *) echo "PR #${pr} is not an agent branch (${branch})."; exit 0 ;;
-          esac
-
-          # Automatic paths share one budget so fix → CI → fix → review cannot loop.
-          if [ "$capped" = "true" ]; then
-            # Filter before parsing: `capture` errors on a non-matching label, which
-            # under `set -e` would abort triage for any PR carrying other labels.
-            used="$(gh pr view "$pr" --repo "$GH_REPO" --json labels \
-              --jq '[.labels[].name
-                       | select(test("^agent-attempt-[0-9]+$"))
-                       | sub("^agent-attempt-"; "")
-                       | tonumber] | max // 0')"
-            if [ "$used" -ge "$MAX_AUTO_ATTEMPTS" ]; then
-              echo "::warning::PR #${pr} has used all ${MAX_AUTO_ATTEMPTS} automatic attempts."
-              gh pr comment "$pr" --repo "$GH_REPO" --body \
-                "🤖 I've used my ${MAX_AUTO_ATTEMPTS} automatic follow-up attempts on this PR without getting it green, so I'm stopping to avoid a loop. Comment \`/agent fix <what to change>\` if you want me to try again with direction." \
-                || echo "::warning::Could not comment on #${pr}."
-              exit 0
-            fi
-            next=$((used + 1))
-            gh pr edit "$pr" --repo "$GH_REPO" --add-label "agent-attempt-${next}" \
-              || echo "::warning::Could not label #${pr}."
-          fi
-
-          {
-            echo "eligible=true"
-            echo "pr=${pr}"
-            echo "branch=${branch}"
-            echo "reason=${reason}"
-          } >> "$GITHUB_OUTPUT"
-
-  fix:
-    needs: triage
-    if: needs.triage.outputs.eligible == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      id-token: write
-      copilot-requests: write
-      pull-requests: write
-      issues: write          # the outcome comment goes through the Issues API
-      actions: read          # `gh run view --log-failed` reads the failing run's log
-    steps:
-      - name: Import secrets
-        id: secrets
-        uses: hashicorp/vault-action@v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          path: ${{ secrets.VAULT_JWT_PATH }}
-          role: ${{ secrets.VAULT_JWT_ROLE }}
-          jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_ID | APP_ID ;
-            secret/data/products/onboarding-and-migration/github.com/apps/camunda/camunda-sdk-automation GITHUB_APP_PRIVATE_KEY | APP_PRIVATE_KEY ;
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ steps.secrets.outputs.APP_ID }}
-          private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Check out the agent branch
-        uses: actions/checkout@v6
-        with:
-          # Read-only token and no persisted credentials while the agent runs with
-          # --yolo; the app token is introduced only at push time.
-          token: ${{ github.token }}
-          persist-credentials: false
-          ref: ${{ needs.triage.outputs.branch }}
-          fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@v7
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Install project dependencies
-        run: uv sync --all-extras --dev
-
-      - name: Install Copilot CLI
-        env:
-          COPILOT_CLI_VERSION: ${{ vars.COPILOT_CLI_VERSION || 'latest' }}
-        run: npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
-
-      - name: Configure committer identity
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          git config --global user.name "${APP_SLUG}[bot]"
-          git config --global user.email "${APP_SLUG}[bot]@users.noreply.github.com"
-
-      - name: Collect the feedback to act on
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ needs.triage.outputs.pr }}
-          REASON: ${{ needs.triage.outputs.reason }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          REVIEW_BODY: ${{ github.event.review.body }}
-          REVIEW_ID: ${{ github.event.review.id }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-        run: |
-          set -euo pipefail
-          # Feedback is author-controlled text, so it goes to a file rather than
-          # through $GITHUB_OUTPUT or an env var interpolated into the prompt.
-          case "$REASON" in
-            comment)
-              printf '%s\n' "$COMMENT_BODY" > /tmp/feedback.md
-              ;;
-            review)
-              {
-                printf '%s\n\n' "$REVIEW_BODY"
-                echo "Inline comments:"
-                gh api "repos/${GH_REPO}/pulls/${PR}/comments" \
-                  --jq ".[] | select(.pull_request_review_id == ${REVIEW_ID}) | \"- \(.path):\(.line // .original_line) — \(.body)\"" \
-                  || true
-              } > /tmp/feedback.md
-              ;;
-            ci)
-              # stderr is deliberately not silenced: if this cannot read the log
-              # (missing `actions: read`, expired logs), that has to be visible in the
-              # run log rather than degrading into an empty prompt the agent guesses at.
-              log="$(gh run view "$RUN_ID" --repo "$GH_REPO" --log-failed | tail -n 200 || true)"
-              if [ -z "${log//[[:space:]]/}" ]; then
-                echo "::error::No failing-step output for run ${RUN_ID}; refusing to run the agent with no feedback."
-                exit 1
-              fi
-              {
-                echo "The CI run failed. Failing step output:"
-                echo
-                printf '%s\n' "$log"
-              } > /tmp/feedback.md
-              ;;
-          esac
-          echo "Collected $(wc -l < /tmp/feedback.md) lines of feedback."
-
-      - name: Run Copilot CLI
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          PR: ${{ needs.triage.outputs.pr }}
-          BRANCH: ${{ needs.triage.outputs.branch }}
-          REASON: ${{ needs.triage.outputs.reason }}
-        run: |
-          set -euo pipefail
-
-          # The feedback is author-controlled (a CI log, a bot review, a comment), so it
-          # is never interpolated into a heredoc: a line equal to the terminator would
-          # truncate or rewrite the prompt. Static parts use quoted heredocs and the
-          # feedback is spliced in as plain data between them.
-          {
-            cat <<'PROMPT_HEAD'
-          You are working on the branch of the pull request named below, which you opened
-          earlier to add SDK example coverage.
-
-          Read AGENTS.md first and follow it strictly.
-
-          Something needs fixing. The trigger and the feedback to act on follow.
-          PROMPT_HEAD
-            printf '\n  Repository: %s\n  Pull request: #%s\n  Branch: %s\n  Trigger: %s\n\n' \
-              "$GITHUB_REPOSITORY" "$PR" "$BRANCH" "$REASON"
-            echo "  Feedback:"
-            sed 's/^/  /' /tmp/feedback.md
-            cat <<'PROMPT_TAIL'
-
-          Do the following:
-          1. Work out the root cause and fix it properly — do not paper over a failing
-             check by weakening or skipping it.
-          2. Stay inside the example surface: examples/, examples/operation-map.json, the
-             docs the repo requires for a new operation, and regenerated SDK output. Do
-             NOT modify generator sources (hooks/, scripts/, the generator project). If
-             the pipeline itself looks like it needs changing, stop and explain that in
-             your final message instead of editing it.
-          3. If you disagree with the feedback, do not change the code — explain your
-             reasoning in your final message instead.
-          4. Commit every change you make and leave the working tree clean.
-          5. Read AGENTS.md for the build/verification pipeline, then finish by running
-             the exact commands below. They are the gate this workflow applies: a green
-             lint, typecheck or test run does NOT mean they pass. Do not stop until
-             every one of them passes.
-          PROMPT_TAIL
-            # $( ) strips every trailing newline, so the blank line before the
-            # closing instruction is emitted here and does not depend on how
-            # VERIFY_COMMANDS happens to be quoted.
-            printf '%s\n\n' "$(printf '%s' "$VERIFY_COMMANDS" | sed 's/^/      /')"
-            cat <<'PROMPT_FOOT'
-          Do not push and do not open a pull request — the workflow does that.
-          PROMPT_FOOT
-          } > /tmp/prompt.md
-
-          copilot --yolo -p "$(cat /tmp/prompt.md)" --model claude-sonnet-4.6
-
-      - name: Verify
-        run: |
-          # `:?` so an empty or unset constant aborts here: `bash -c ""` exits 0,
-          # which would turn a missing gate into a silently passing one.
-          bash -euo pipefail -c "${VERIFY_COMMANDS:?is empty; refusing to run an empty verify gate}"
-
-      - name: Push any fix
-        id: push
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          BRANCH: ${{ needs.triage.outputs.branch }}
-        run: |
-          set -euo pipefail
-
-          # --porcelain rather than `git diff`, so untracked leftovers (scratch files,
-          # stray build output) also fail the run. The prompt demands a clean tree, and
-          # tracked-only checks let the most common form of mess through. Ignored paths
-          # are still excluded, so normal build artefacts do not trip this.
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::The agent left the working tree dirty; refusing to push a partial fix."
-            git status --short
-            exit 1
-          fi
-
-          if [ -z "$(git log --oneline "origin/${BRANCH}..HEAD")" ]; then
-            echo "::warning::The agent made no commits."
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git push \
-            "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPO}.git" \
-            "HEAD:refs/heads/${BRANCH}"
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Report back on the pull request
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR: ${{ needs.triage.outputs.pr }}
-          REASON: ${{ needs.triage.outputs.reason }}
-          RESULT: ${{ job.status }}
-          PUSHED: ${{ steps.push.outputs.pushed }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          case "${RESULT}:${PUSHED:-false}" in
-            success:true)
-              msg="🤖 Pushed a fix in response to the ${REASON} feedback. Checks will re-run — please re-review." ;;
-            success:false)
-              msg="🤖 I looked at the ${REASON} feedback but made no changes. See the [run log](${RUN_URL}) for my reasoning — this one needs a human." ;;
-            *)
-              msg="🤖 My follow-up attempt failed — see the [run log](${RUN_URL}). Comment \`/agent fix <what to change>\` to point me at it more precisely." ;;
-          esac
-          gh pr comment "$PR" --repo "$GH_REPO" --body "$msg" || echo "::warning::Could not comment on #${PR}."
+      id-token: write          # mint GitHub OIDC token for Vault JWT auth
+      copilot-requests: write  # Copilot CLI auth via GITHUB_TOKEN (billed to the org)
+      pull-requests: write     # attempt labels and the outcome comment
+      issues: write            # PR comments go through the Issues API
+      actions: read            # read the failing run's log
+    uses: camunda/sdk-infra/.github/workflows/sdk-agent-pr-followup.yml@v1
+    # Explicit rather than `inherit`: the shared workflow needs only Vault auth,
+    # and this job hands the repo to an LLM agent.
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
+      VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
+      VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
+    with:
+      language: python
+      verify-commands: |
+        uv run python scripts/check_example_coverage.py
+        uv run python scripts/check_method_example_completeness.py
+        make lint
+        make typecheck
+        make sync-readme-check
+        make test
+      # `uv run` resolves the environment and may re-pin the lockfile.
+      verify-artifacts: |
+        uv.lock


### PR DESCRIPTION
## Why

The example-coverage agent — the workflow that resolves an auto-filed `new-operations`
issue by writing the missing examples and opening a PR — was implemented independently in
this repo, the JS repo and the C# repo. Three implementations of the same idea drifted, and
the drift showed up in the run history:

| SDK | Agent runs that produced a mergeable PR |
| --- | --- |
| C# | 3 / 3 |
| JS | 2 / 2 (one earlier run failed on a recorded fixture) |
| **Python** | **1 / 3** |

Both failures were the same shape: the agent finished its work, a verify command
regenerated a tracked file, and the workflow could not tell "the agent left something
uncommitted" apart from "verification touched a lockfile". Here that file was `uv.lock`
(#241); in the JS repo it was `json-body-assertions/responses.json`.

The mechanics now live in [`camunda/sdk-infra`](https://github.com/camunda/sdk-infra/pull/29)
so all five SDKs share one implementation, and the ambiguity above is fixed properly.

## What changed

`agent-example-coverage.yml` and `agent-pr-followup.yml` become thin callers: **93 lines in,
732 lines out**. They keep only what is genuinely repo-specific — the language, the job
permissions, the triggers, and the commands that define "verified" here.

Two details are load-bearing for this repo in particular:

- **Ordering is `agent → inspect → verify → reconcile → push`.** Inspecting the working tree
  *before* verification runs is the only moment at which a dirty tree unambiguously means
  the agent left work uncommitted.
- **`verify-artifacts` declares `uv.lock`.** `uv run` resolves the environment and may
  re-pin the lockfile, so it is allow-listed. Anything the verify commands touch *outside*
  that list now fails the run loudly instead of being swept into the commit.

## Testing

The shared workflows are merged and `v1` points at them. This is the first repo to adopt
them, deliberately: #241 is the run that previously failed on `uv.lock`, so a green run here
proves the fix rather than just proving the plumbing.

Plan after merge: re-run the agent against #241 via `workflow_dispatch` and confirm it
produces a mergeable PR.

## Follow-up

The Go and Rust repos have caller PRs open too, but neither has the `VAULT_*` secrets the
shared workflow requires, so they are held until those are provisioned.
